### PR TITLE
Fix overlapping Runme execution, no longer removes ENV vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 toolchain go1.23.7
 
 // Use: https://github.com/runmedev/runme/tree/seb/env-collector
-replace github.com/stateful/runme/v3 => github.com/runmedev/runme/v3 v3.12.7-0.20250331220551-44d398274863
+replace github.com/stateful/runme/v3 => github.com/runmedev/runme/v3 v3.12.7-0.20250401222817-f3fcbae68653
 
 require (
 	connectrpc.com/connect v1.18.1

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
-github.com/runmedev/runme/v3 v3.12.7-0.20250331220551-44d398274863 h1:HFHKujQ9+ITTPZEm9iBUEdS9IKwELV+6iaE9YS2/QI8=
-github.com/runmedev/runme/v3 v3.12.7-0.20250331220551-44d398274863/go.mod h1:LOmfMGLDKWpnX90tGNkeHsbxyc8ETGr1pcS1sNkoltA=
+github.com/runmedev/runme/v3 v3.12.7-0.20250401222817-f3fcbae68653 h1:IxyFDc9VmzUcWiUU7mrIA95OxRaLEk1J2Drl6wVhqBM=
+github.com/runmedev/runme/v3 v3.12.7-0.20250401222817-f3fcbae68653/go.mod h1:LOmfMGLDKWpnX90tGNkeHsbxyc8ETGr1pcS1sNkoltA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=


### PR DESCRIPTION
Runner v2 had a bug where SIGKILL/SIGINT would lead to an empty slice for post execution environment vars, effectively removing valid variables from the session. This PR pulls in the latest commits that fix the underlying issue.

Relevant Runme PR: https://github.com/runmedev/runme/pull/772