### PR TITLE
Parse codeblocks in markdown into separate runme blocks

### DIFF
--- a/app/pkg/ai/blocks.go
+++ b/app/pkg/ai/blocks.go
@@ -4,6 +4,7 @@ import (
 	"connectrpc.com/connect"
 	"context"
 	"encoding/json"
+	"github.com/jlewi/cloud-assistant/app/pkg/docs"
 	"github.com/jlewi/cloud-assistant/app/pkg/logs"
 	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
 	"github.com/openai/openai-go/packages/ssestream"
@@ -161,13 +162,13 @@ func (b *BlocksBuilder) ProcessEvent(ctx context.Context, e responses.ResponseSt
 	case responses.ResponseOutputItemDoneEvent:
 		item := e.AsResponseOutputItemDone()
 		log.Info("Output item done", "item", item)
-		block, err := b.itemDoneToBlock(ctx, item.Item)
+		blocks, err := b.itemDoneToBlock(ctx, item.Item)
 		if err != nil {
 			return err
 		}
 
-		if block != nil {
-			resp.Blocks = append(resp.Blocks, block)
+		if blocks != nil {
+			resp.Blocks = append(resp.Blocks, blocks...)
 		}
 	//case responses.ResponseFileSearchCallCompletedEvent:
 
@@ -187,13 +188,38 @@ func (b *BlocksBuilder) ProcessEvent(ctx context.Context, e responses.ResponseSt
 	return nil
 }
 
-func (b *BlocksBuilder) itemDoneToBlock(ctx context.Context, item responses.ResponseOutputItemUnion) (*cassie.Block, error) {
+func (b *BlocksBuilder) itemDoneToBlock(ctx context.Context, item responses.ResponseOutputItemUnion) ([]*cassie.Block, error) {
+	log := logs.FromContext(ctx)
+	results := make([]*cassie.Block, 0, 5)
 	switch item.AsAny().(type) {
 	case responses.ResponseOutputMessage:
+		// For regular output messages we want to parse out any code blocks and turn them into code blocks
+		// so they get rendered as executable code. This is a bit of a hack to make them executable.
+		m := item.AsMessage()
+		for _, message := range m.Content {
+			if message.Text == "" {
+				continue
+			}
+
+			parsedBlocks, err := docs.MarkdownToBlocks(message.Text)
+			if err != nil {
+				log.Error(err, "Failed to parse markdown", "text", message.Text)
+				continue
+			}
+
+			for _, b := range parsedBlocks {
+				if b.Kind == cassie.BlockKind_CODE {
+					results = append(results, b)
+				}
+			}
+		}
+		return results, nil
 	case responses.ResponseFileSearchToolCall:
-		return b.fileSearchDoneItemToBlock(ctx, item.AsFileSearchCall())
+		b, err := b.fileSearchDoneItemToBlock(ctx, item.AsFileSearchCall())
+		results = append(results, b)
+		return results, err
 	}
-	return nil, nil
+	return results, nil
 }
 
 // N.B. It doesn't look like the file search call actually has the results in it. I think its the item done.

--- a/app/pkg/ai/blocks.go
+++ b/app/pkg/ai/blocks.go
@@ -189,6 +189,7 @@ func (b *BlocksBuilder) ProcessEvent(ctx context.Context, e responses.ResponseSt
 
 func (b *BlocksBuilder) itemDoneToBlock(ctx context.Context, item responses.ResponseOutputItemUnion) (*cassie.Block, error) {
 	switch item.AsAny().(type) {
+	case responses.ResponseOutputMessage:
 	case responses.ResponseFileSearchToolCall:
 		return b.fileSearchDoneItemToBlock(ctx, item.AsFileSearchCall())
 	}

--- a/app/pkg/docs/converters.go
+++ b/app/pkg/docs/converters.go
@@ -1,0 +1,91 @@
+package docs
+
+import (
+  "github.com/jlewi/cloud-assistant/app/pkg/runme/converters"
+  "github.com/jlewi/cloud-assistant/protos/gen/cassie"
+  parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
+  "github.com/stateful/runme/v3/pkg/document/editor"
+  "github.com/stateful/runme/v3/pkg/document/identity"
+)
+
+const (
+  OUTPUTLANG = "output"
+)
+
+// MarkdownToBlocks converts a markdown string into a sequence of blocks.
+// This function relies on RunMe's Markdown->Cells conversion; underneath the hood that uses goldmark to walk the AST.
+// RunMe's deserialization function doesn't have any notion of output in markdown. However, in Foyle outputs
+// are rendered to code blocks of language "output". So we need to do some post processing to convert the outputs
+// into output items
+func MarkdownToBlocks(mdText string) ([]*cassie.Block, error) {
+  // N.B. We don't need to add any identities
+  resolver := identity.NewResolver(identity.UnspecifiedLifecycleIdentity)
+  options := editor.Options{
+    IdentityResolver: resolver,
+  }
+  notebook, err := editor.Deserialize([]byte(mdText), options)
+
+  blocks := make([]*cassie.Block, 0, len(notebook.Cells))
+
+  var lastCodeBlock *cassie.Block
+  for _, cell := range notebook.Cells {
+
+    var tr *parserv1.TextRange
+
+    if cell.TextRange != nil {
+      tr = &parserv1.TextRange{
+        Start: uint32(cell.TextRange.Start),
+        End:   uint32(cell.TextRange.End),
+      }
+    }
+
+    cellPb := &parserv1.Cell{
+      Kind:       parserv1.CellKind(cell.Kind),
+      Value:      cell.Value,
+      LanguageId: cell.LanguageID,
+      Metadata:   cell.Metadata,
+      TextRange:  tr,
+    }
+
+    block, err := converters.CellToBlock(cellPb)
+    if err != nil {
+      return nil, err
+    }
+
+    // We need to handle the case where the block is an output code block.
+    if block.Kind == cassie.BlockKind_CODE {
+      if block.Language == OUTPUTLANG {
+        // This is an output block
+        // We need to append the output to the last code block
+        if lastCodeBlock != nil {
+          if lastCodeBlock.Outputs == nil {
+            lastCodeBlock.Outputs = make([]*cassie.BlockOutput, 0, 1)
+          }
+          lastCodeBlock.Outputs = append(lastCodeBlock.Outputs, &cassie.BlockOutput{
+            Items: []*cassie.BlockOutputItem{
+              {
+                TextData: block.Contents,
+              },
+            },
+          })
+          continue
+        }
+
+        // Since we don't have a code block to add the output to just treat it as a code block
+      } else {
+        // Update the lastCodeBlock
+        lastCodeBlock = block
+      }
+    } else {
+      // If we have a non-nil markup block then we zero out lastCodeBlock so that a subsequent output block
+      // wouldn't be added to the last code block.
+      if block.GetContents() != "" {
+        lastCodeBlock = nil
+      }
+    }
+
+    blocks = append(blocks, block)
+  }
+
+  return blocks, err
+}

--- a/app/pkg/docs/converters_test.go
+++ b/app/pkg/docs/converters_test.go
@@ -1,0 +1,165 @@
+package docs
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jlewi/cloud-assistant/app/pkg/testutil"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_MarkdownToBlocks(t *testing.T) {
+	type testCase struct {
+		name     string
+		inFile   string
+		expected []*cassie.Block
+	}
+
+	cases := []testCase{
+		{
+			name:   "simple",
+			inFile: "testdoc.md",
+			expected: []*cassie.Block{
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "# Section 1",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "This is section 1",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind: cassie.BlockKind_CODE,
+					Metadata: map[string]string{
+						"runme.dev/name":          "package-main",
+						"runme.dev/nameGenerated": "true",
+					},
+					Language: "go",
+					Contents: "package main\n\nfunc main() {\n...\n}",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "Breaking text",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind: cassie.BlockKind_CODE,
+					Metadata: map[string]string{
+						"runme.dev/name":          "echo-hello",
+						"runme.dev/nameGenerated": "true",
+					},
+					Language: "bash",
+					Contents: "echo \"Hello, World!\"",
+					Outputs: []*cassie.BlockOutput{
+						{
+							Items: []*cassie.BlockOutputItem{
+								{
+									TextData: "hello, world!",
+								}},
+						},
+					},
+				},
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "## Subsection",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+			},
+		},
+		{
+			name:   "list-nested",
+			inFile: "list.md",
+			expected: []*cassie.Block{
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "Test code blocks nested in a list",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "1. First command",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind: cassie.BlockKind_CODE,
+					Metadata: map[string]string{
+						"runme.dev/name":          "echo-1",
+						"runme.dev/nameGenerated": "true",
+					},
+					Language: "bash",
+					Contents: "echo 1",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind:     cassie.BlockKind_MARKUP,
+					Metadata: make(map[string]string),
+					Contents: "2. Second command",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+				{
+					Kind: cassie.BlockKind_CODE,
+					Metadata: map[string]string{
+						"runme.dev/name":          "echo-2",
+						"runme.dev/nameGenerated": "true",
+					},
+					Language: "bash",
+					Contents: "echo 2",
+					Outputs:  []*cassie.BlockOutput{},
+				},
+			},
+		},
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fPath := filepath.Join(cwd, "test_data", c.inFile)
+			raw, err := os.ReadFile(fPath)
+			if err != nil {
+				t.Fatalf("Failed to read raw file: %v", err)
+			}
+			actual, err := MarkdownToBlocks(string(raw))
+			if err != nil {
+				t.Fatalf("MarkdownToBlocks(%v) returned error %v", c.inFile, err)
+			}
+			if len(actual) != len(c.expected) {
+				t.Errorf("Expected %v blocks got %v", len(c.expected), len(actual))
+			}
+
+			for i, eBlock := range c.expected {
+				if i >= len(actual) {
+					break
+				}
+
+				aBlock := actual[i]
+
+				opts := cmp.Options{
+					// ignore Id because it will be unique each time it gets run
+					cmpopts.IgnoreFields(cassie.Block{}, "Id"),
+				}
+
+				// Zero out the metadata field for id
+				delete(aBlock.Metadata, "runme.dev/id")
+
+				if d := cmp.Diff(eBlock, aBlock, testutil.BlockComparer, opts); d != "" {
+					t.Errorf("Unexpected diff block %d:\n%s", i, d)
+				}
+			}
+		})
+	}
+}

--- a/app/pkg/docs/test_data/list.md
+++ b/app/pkg/docs/test_data/list.md
@@ -1,0 +1,10 @@
+Test code blocks nested in a list
+
+1. First command
+    ```bash
+    echo 1
+    ```
+1. Second command
+    ```bash
+    echo 2
+    ```

--- a/app/pkg/docs/test_data/testdoc.md
+++ b/app/pkg/docs/test_data/testdoc.md
@@ -1,0 +1,23 @@
+# Section 1
+
+This is section 1
+
+```go
+package main
+
+func main() {
+...
+}
+```
+
+Breaking text
+
+```bash
+echo "Hello, World!"
+```
+
+```output
+hello, world!
+```
+
+## Subsection

--- a/app/pkg/runme/converters/cell_to_blocks.go
+++ b/app/pkg/runme/converters/cell_to_blocks.go
@@ -1,0 +1,127 @@
+package converters
+
+import (
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
+	"github.com/pkg/errors"
+	parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
+)
+
+// Doc represents a document
+// This is a hack for when we copied this code over from foyle; if we keep doc; we should make it a proto.
+type Doc struct {
+	Blocks []*cassie.Block
+}
+
+// NotebookToDoc converts a runme Notebook to a foyle Doc
+func NotebookToDoc(nb *parserv1.Notebook) (*Doc, error) {
+	if nb == nil {
+		return nil, errors.New("Notebook is nil")
+	}
+
+	doc := &Doc{
+		Blocks: make([]*cassie.Block, 0, len(nb.Cells)),
+	}
+
+	for _, cell := range nb.Cells {
+		block, err := CellToBlock(cell)
+		if err != nil {
+			return nil, err
+		}
+		doc.Blocks = append(doc.Blocks, block)
+	}
+
+	return doc, nil
+}
+
+// CellToBlock converts a runme Cell to a foyle Block
+//
+// N.B. cell metadata is currently ignored.
+func CellToBlock(cell *parserv1.Cell) (*cassie.Block, error) {
+	if cell == nil {
+		return nil, errors.New("Cell is nil")
+	}
+
+	blockOutputs := make([]*cassie.BlockOutput, 0, len(cell.Outputs))
+
+	for _, output := range cell.Outputs {
+		bOutput, err := CellOutputToBlockOutput(output)
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to convert CellOutput to BlockOutput")
+		}
+		blockOutputs = append(blockOutputs, bOutput)
+	}
+	blockKind := CellKindToBlockKind(cell.Kind)
+
+	id := ""
+	if cell.Metadata != nil {
+		newId := GetCellID(cell)
+		if newId != "" {
+			id = newId
+		}
+	}
+
+	return &cassie.Block{
+		Id:       id,
+		Language: cell.LanguageId,
+		Contents: cell.Value,
+		Kind:     blockKind,
+		Outputs:  blockOutputs,
+		Metadata: cell.Metadata,
+	}, nil
+}
+
+// GetCellID returns the ID of a cell if it exists or none if it doesn't
+func GetCellID(cell *parserv1.Cell) string {
+	if cell.Metadata != nil {
+		// See this thread
+		// See this thread https://discord.com/channels/1102639988832735374/1218835142962053193/1278863895813165128
+		// RunMe uses two different fields for the ID field. We check both because the field we get could depend
+		// On how the cell was generated e.g. whether it went through the serializer or not.
+		if id, ok := cell.Metadata[RunmeIdField]; ok {
+			return id
+		}
+		if id, ok := cell.Metadata[IdField]; ok {
+			return id
+		}
+	}
+	return ""
+}
+
+func SetCellID(cell *parserv1.Cell, id string) {
+	// Delete any existing IDs
+	for _, idField := range []string{IdField, RunmeIdField} {
+		delete(cell.Metadata, idField)
+	}
+	cell.Metadata[RunmeIdField] = id
+}
+
+func CellKindToBlockKind(kind parserv1.CellKind) cassie.BlockKind {
+	switch kind {
+	case parserv1.CellKind_CELL_KIND_CODE:
+		return cassie.BlockKind_CODE
+	case parserv1.CellKind_CELL_KIND_MARKUP:
+		return cassie.BlockKind_MARKUP
+	default:
+		return cassie.BlockKind_UNKNOWN_BLOCK_KIND
+	}
+}
+
+func CellOutputToBlockOutput(output *parserv1.CellOutput) (*cassie.BlockOutput, error) {
+	if output == nil {
+		return nil, errors.New("CellOutput is nil")
+	}
+
+	boutput := &cassie.BlockOutput{
+		Items: make([]*cassie.BlockOutputItem, 0, len(output.Items)),
+	}
+
+	for _, oi := range output.Items {
+		boi := &cassie.BlockOutputItem{
+			Mime:     oi.Mime,
+			TextData: string(oi.Data),
+		}
+		boutput.Items = append(boutput.Items, boi)
+	}
+
+	return boutput, nil
+}

--- a/app/pkg/runme/converters/cell_to_blocks_test.go
+++ b/app/pkg/runme/converters/cell_to_blocks_test.go
@@ -1,0 +1,137 @@
+package converters
+
+import (
+	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/jlewi/cloud-assistant/app/pkg/testutil"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
+	parserv1 "github.com/stateful/runme/v3/pkg/api/gen/proto/go/runme/parser/v1"
+	"testing"
+)
+
+type testCase struct {
+	name     string
+	Notebook *parserv1.Notebook
+	Doc      *Doc
+}
+
+var (
+	cases = []testCase{
+		{
+			name: "Simple",
+			Notebook: &parserv1.Notebook{
+				Cells: []*parserv1.Cell{
+					{
+						Metadata: map[string]string{
+							"id":          "1234",
+							"interactive": "false",
+						},
+						Kind:       parserv1.CellKind_CELL_KIND_CODE,
+						LanguageId: "python",
+						Value:      "print('Hello World')",
+						Outputs: []*parserv1.CellOutput{
+							{
+								Items: []*parserv1.CellOutputItem{
+									{
+										Data: []byte("Hello World\n"),
+										Mime: "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Doc: &Doc{
+				Blocks: []*cassie.Block{
+					{
+						Id:       "1234",
+						Language: "python",
+						Contents: "print('Hello World')",
+						Metadata: map[string]string{
+							"id":          "1234",
+							"interactive": "false",
+						},
+						Kind: cassie.BlockKind_CODE,
+						Outputs: []*cassie.BlockOutput{
+							{
+								Items: []*cassie.BlockOutputItem{
+									{
+										TextData: "Hello World\n",
+										Mime:     "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// This test case we don't set interactive explicitly.
+			// It verifies its not getting added
+			name: "no-interactive",
+			Notebook: &parserv1.Notebook{
+				Cells: []*parserv1.Cell{
+					{
+						Metadata: map[string]string{
+							"id": "1234",
+						},
+						Kind:       parserv1.CellKind_CELL_KIND_CODE,
+						LanguageId: "python",
+						Value:      "print('Hello World')",
+						Outputs: []*parserv1.CellOutput{
+							{
+								Items: []*parserv1.CellOutputItem{
+									{
+										Data: []byte("Hello World\n"),
+										Mime: "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Doc: &Doc{
+				Blocks: []*cassie.Block{
+					{
+						Id:       "1234",
+						Language: "python",
+						Contents: "print('Hello World')",
+						Metadata: map[string]string{
+							"id": "1234",
+						},
+						Kind: cassie.BlockKind_CODE,
+						Outputs: []*cassie.BlockOutput{
+							{
+								Items: []*cassie.BlockOutputItem{
+									{
+										TextData: "Hello World\n",
+										Mime:     "text/plain",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func Test_NotebookToDoc(t *testing.T) {
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("Case %d", i), func(t *testing.T) {
+			actual, err := NotebookToDoc(c.Notebook)
+			if err != nil {
+				t.Errorf("Case %v: Error %v", i, err)
+				return
+			}
+
+			if diff := cmp.Diff(c.Doc, actual, testutil.BlockComparer); diff != "" {
+				t.Errorf("Unexpected Diff:\n%v", diff)
+			}
+		})
+	}
+}

--- a/app/pkg/runme/converters/const.go
+++ b/app/pkg/runme/converters/const.go
@@ -1,0 +1,10 @@
+package converters
+
+const (
+	// See this thread https://discord.com/channels/1102639988832735374/1218835142962053193/1278863895813165128
+
+	// RunmeIdField is the field name for the ID that Runme uses in memory
+	RunmeIdField = "runme.dev/id"
+	// IdField is the field name for the ID field when it is serialized
+	IdField = "id"
+)

--- a/app/pkg/testutil/comparers.go
+++ b/app/pkg/testutil/comparers.go
@@ -1,0 +1,10 @@
+package testutil
+
+import (
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
+)
+
+var (
+	BlockComparer = cmpopts.IgnoreUnexported(cassie.Block{}, cassie.BlockOutput{}, cassie.BlockOutputItem{})
+)


### PR DESCRIPTION
The model has a tendency to respond with markdown inside code blocks.
We want these to show as runme consoles so we explicitly parse them out.