### PR TITLE
Generic OIDC to support, e.g. Azure's Entra ID

### DIFF
--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -1,0 +1,34 @@
+name: bundle-web
+
+on:
+  push:
+    paths:
+      - 'web/**'
+      - '.github/workflows/test-web.yaml'
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/test-web.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: cd web && npm install
+
+      - name: Build
+        run: cd web && npm run build

--- a/.github/workflows/test-web.yaml
+++ b/.github/workflows/test-web.yaml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
 
       - name: Install dependencies
-        run: cd web && npm install
+        run: npm install
 
       - name: Build
-        run: cd web && npm run build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ assistantServer:
         google:
             clientCredentialsFile: /Users/${USER}/.cloud-assistant/client_credentials.json
             discoveryURL: https://accounts.google.com/.well-known/openid-configuration
+        generic:
+            clientID: your-client-id-here
+            clientSecret: your-client-secret-here
+            redirectURL: http://localhost:8080/auth/callback
+            discoveryURL: https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+            scopes:
+                - "openid"
+                - "email"
+            issuer: https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 # TODO: change this to your own tenant ID
         domains:
             - "evilcorp.com"
             - "myemail.com"

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -344,6 +344,9 @@ type OIDCConfig struct {
 	// Google contains Google-specific OIDC configuration
 	Google *GoogleOIDCConfig `json:"google,omitempty" yaml:"google,omitempty"`
 
+	// Generic contains generic OIDC configuration
+	Generic *GenericOIDCConfig `json:"generic,omitempty" yaml:"generic,omitempty"`
+
 	// Domains is a list of allowed domains for OIDC authentication
 	Domains []string `json:"domains" yaml:"domains"`
 
@@ -359,12 +362,33 @@ type GoogleOIDCConfig struct {
 	DiscoveryURL string `json:"discoveryURL" yaml:"discoveryURL"`
 }
 
+// GenericOIDCConfig contains configuration for a generic OIDC provider
+type GenericOIDCConfig struct {
+	// ClientID is the OAuth2 client ID
+	ClientID string `json:"clientID" yaml:"clientID"`
+	// ClientSecret is the OAuth2 client secret
+	ClientSecret string `json:"clientSecret" yaml:"clientSecret"`
+	// RedirectURL is the URL to redirect users to after login
+	RedirectURL string `json:"redirectURL" yaml:"redirectURL"`
+	// DiscoveryURL is the URL for the OpenID Connect discovery document
+	DiscoveryURL string `json:"discoveryURL" yaml:"discoveryURL"`
+	// Scopes are the OAuth2 scopes to request (optional, defaults to ["openid", "email"])
+	Scopes []string `json:"scopes" yaml:"scopes"`
+	// Issuer allows overwriting the URL for the OpenID Connect issuer
+	Issuer string `json:"issuer" yaml:"issuer"`
+}
+
 // Add a helper method to get the discovery URL with a default
 func (c *GoogleOIDCConfig) GetDiscoveryURL() string {
 	if c.DiscoveryURL != "" {
 		return c.DiscoveryURL
 	}
 	return "https://accounts.google.com/.well-known/openid-configuration"
+}
+
+// GetDiscoveryURL returns the discovery URL for the generic OIDC provider
+func (c *GenericOIDCConfig) GetDiscoveryURL() string {
+	return c.DiscoveryURL
 }
 
 func (c *AssistantServerConfig) GetBindAddress() string {

--- a/app/pkg/server/assets.go
+++ b/app/pkg/server/assets.go
@@ -71,17 +71,17 @@ func processIndexHTMLWithConfig(assetsFS fs.FS, oidcConfig *config.OIDCConfig) (
 	return content, nil
 }
 
-// serveSinglePageApp serves a single-page app from static or embedded assets,
+// singlePageAppHandler serves a single-page app from static or embedded assets,
 // falling back to index for client-side routing when files don't exist.
-func (s *Server) serveSinglePageApp() error {
+func (s *Server) singlePageAppHandler() (http.Handler, error) {
 	assetsFS, err := getAssetFileSystem(s.serverConfig.StaticAssets)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to get asset handler")
+		return nil, errors.Wrapf(err, "Failed to get asset handler")
 	}
 
 	fileServer := http.FileServer(http.FS(assetsFS))
 
-	s.engine.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := "/"
 		if len(r.URL.Path) > 1 {
 			path = r.URL.Path[1:]
@@ -106,7 +106,5 @@ func (s *Server) serveSinglePageApp() error {
 		}
 
 		fileServer.ServeHTTP(w, r)
-	}))
-
-	return nil
+	}), nil
 }

--- a/app/pkg/server/assets.go
+++ b/app/pkg/server/assets.go
@@ -47,7 +47,11 @@ func processIndexHTMLWithConfig(assetsFS fs.FS, oidcConfig *config.OIDCConfig) (
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open index.html")
 	}
-	defer file.Close()
+	defer func() {
+		if err := file.Close(); err != nil {
+			zap.L().Error("failed to close index.html file", zap.Error(err))
+		}
+	}()
 
 	// Read the file content
 	buf := new(bytes.Buffer)
@@ -101,7 +105,7 @@ func (s *Server) singlePageAppHandler() (http.Handler, error) {
 
 			// Set content type and write the modified content
 			w.Header().Set("Content-Type", "text/html")
-			w.Write(content)
+			_, _ = w.Write(content)
 			return
 		}
 

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -73,7 +73,11 @@ func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
 	var discovery openIDDiscovery
 	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
@@ -129,7 +133,11 @@ func (o *OIDC) downloadJWKS() error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
 	// Parse the JWKS into our structured format
 	var jwks jwks

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	oidcPathPrefix = "/oidc"
-	sessionCookieName = "session"
+	sessionCookieName = "cassie-session"
 	stateLength = 32
 )
 

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	authPathPrefix = "/auth"
+	oidcPathPrefix = "/oidc"
 	sessionCookieName = "session"
 	stateLength = 32
 )
@@ -262,9 +262,9 @@ func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
 	}
 
 	// Register OAuth2 endpoints
-	mux.HandleFunc(authPathPrefix+"/login", oidc.loginHandler)
-	mux.HandleFunc(authPathPrefix+"/callback", oidc.callbackHandler)
-	mux.HandleFunc(authPathPrefix+"/logout", oidc.logoutHandler)
+	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
+	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
+	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
 
 	return nil
 }
@@ -288,7 +288,7 @@ func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handl
 			log := zapr.NewLogger(zap.L())
 
 			// Skip authentication for login page and OAuth2 endpoints
-			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, authPathPrefix+"/") {
+			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -297,7 +297,7 @@ func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handl
 			cookie, err := r.Cookie(sessionCookieName)
 			if err != nil {
 				// No session cookie, redirect to login
-				http.Redirect(w, r, authPathPrefix+"/login", http.StatusFound)
+				http.Redirect(w, r, oidcPathPrefix+"/login", http.StatusFound)
 				return
 			}
 
@@ -308,7 +308,7 @@ func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handl
 			if !valid {
 				log.Error(err, "Token validation failed")
 				// This could lead to an infinite redirect loop, browsers detect this and stop it
-				http.Redirect(w, r, authPathPrefix+"/login", http.StatusFound)
+				http.Redirect(w, r, oidcPathPrefix+"/login", http.StatusFound)
 				return
 			}
 

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -268,8 +268,8 @@ func RequireOIDC(config *config.OIDCConfig, mux *http.ServeMux) (*http.ServeMux,
 	protectedMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		log := zapr.NewLogger(zap.L())
 
-		// Skip authentication for health checks and OAuth2 endpoints
-		if r.URL.Path == "/health" || strings.HasPrefix(r.URL.Path, authPathPrefix+"/") {
+		// Skip authentication for login page and OAuth2 endpoints
+		if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, authPathPrefix+"/") {
 			mux.ServeHTTP(w, r)
 			return
 		}

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -265,6 +265,7 @@ func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
 	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
 	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
 	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
+	mux.HandleFunc("/logout", oidc.logoutHandler)
 
 	return nil
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -1,0 +1,513 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
+)
+
+func TestStateManager(t *testing.T) {
+	sm := newStateManager(6 * time.Second)
+
+	// Test state generation
+	state, err := sm.generateState()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+	if state == "" {
+		t.Error("Generated state is empty")
+	}
+
+	// Test state validation
+	if !sm.validateState(state) {
+		t.Error("Valid state was not accepted")
+	}
+	if sm.validateState(state) {
+		t.Error("State was accepted twice")
+	}
+
+	// Test state expiration
+	state, err = sm.generateState()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+	time.Sleep(sm.stateExpiration + time.Second)
+	if sm.validateState(state) {
+		t.Error("Expired state was accepted")
+	}
+}
+
+func TestOIDC_NewOIDC(t *testing.T) {
+	// Test with nil config
+	oidc, err := newOIDC(nil)
+	if err != nil {
+		t.Errorf("Expected no error with nil config, got %v", err)
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with nil config")
+	}
+
+	// Test with nil Google config
+	cfg := &config.OIDCConfig{}
+	oidc, err = newOIDC(cfg)
+	if err != nil {
+		t.Errorf("Expected no error with nil Google config, got %v", err)
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with nil Google config")
+	}
+
+	// Test with invalid config
+	cfg.Google = &config.GoogleOIDCConfig{
+		ClientCredentialsFile: "nonexistent.json",
+	}
+	oidc, err = newOIDC(cfg)
+	if err == nil {
+		t.Error("Expected error with invalid config")
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with invalid config")
+	}
+}
+
+func TestOIDC_Handlers(t *testing.T) {
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
+	oidc, err := newOIDC(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create OIDC instance: %v", err)
+	}
+
+	t.Run("LoginHandler", func(t *testing.T) {
+		// Create a test request
+		req := httptest.NewRequest("GET", "/auth/login", nil)
+		w := httptest.NewRecorder()
+
+		// Call the handler
+		oidc.loginHandler(w, req)
+
+		// Check the response
+		resp := w.Result()
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+		}
+
+		// Parse the redirect URL
+		redirectURL, err := url.Parse(resp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("Failed to parse redirect URL: %v", err)
+		}
+
+		// Verify the URL contains required parameters
+		if redirectURL.Host != "accounts.google.com" {
+			t.Errorf("Expected host accounts.google.com, got %s", redirectURL.Host)
+		}
+		if clientID := redirectURL.Query().Get("client_id"); clientID != "dummy-client-id" {
+			t.Errorf("Expected client_id dummy-client-id, got %s", clientID)
+		}
+		if state := redirectURL.Query().Get("state"); state == "" {
+			t.Error("Expected non-empty state parameter")
+		}
+	})
+
+	t.Run("CallbackHandler", func(t *testing.T) {
+		// Generate a valid state
+		state, err := oidc.state.generateState()
+		if err != nil {
+			t.Fatalf("Failed to generate state: %v", err)
+		}
+
+		// Create a test request with invalid state
+		req := httptest.NewRequest("GET", "/auth/callback?state=invalid&code=test-code", nil)
+		w := httptest.NewRecorder()
+		oidc.callbackHandler(w, req)
+		if status := w.Result().StatusCode; status != http.StatusBadRequest {
+			t.Errorf("Expected status %d, got %d", http.StatusBadRequest, status)
+		}
+
+		// Create a test request with valid state but no code
+		req = httptest.NewRequest("GET", "/auth/callback?state="+state, nil)
+		w = httptest.NewRecorder()
+		oidc.callbackHandler(w, req)
+		if status := w.Result().StatusCode; status != http.StatusInternalServerError {
+			t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, status)
+		}
+	})
+
+	t.Run("LogoutHandler", func(t *testing.T) {
+		// Create a test request
+		req := httptest.NewRequest("GET", "/auth/logout", nil)
+		w := httptest.NewRecorder()
+
+		// Call the handler
+		oidc.logoutHandler(w, req)
+
+		// Check the response
+		resp := w.Result()
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+		}
+
+		// Verify the cookie is cleared
+		cookies := resp.Cookies()
+		if len(cookies) != 1 {
+			t.Errorf("Expected 1 cookie, got %d", len(cookies))
+		}
+		cookie := cookies[0]
+		if cookie.Name != sessionCookieName {
+			t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
+		}
+		if cookie.Value != "" {
+			t.Error("Expected empty cookie value")
+		}
+		if cookie.MaxAge != -1 {
+			t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+		}
+	})
+}
+
+func TestOIDC_DownloadJWKS(t *testing.T) {
+	// Create a test server to mock the JWKS endpoint
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Create a test RSA key
+		key := &rsa.PublicKey{
+			N: big.NewInt(12345),
+			E: 65537,
+		}
+
+		// Create a test JWKS response
+		jwks := &jwks{
+			Keys: []jwksKey{
+				{
+					Kty: "RSA",
+					Alg: "RS256",
+					Use: "sig",
+					Kid: "test-key",
+					N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+					E:   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
+				},
+			},
+		}
+
+		json.NewEncoder(w).Encode(jwks)
+	}))
+	defer ts.Close()
+
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL: "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
+	oidc, err := newOIDC(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create OIDC instance: %v", err)
+	}
+
+	// Override the discovery document with our test server URL
+	oidc.discovery.JWKSURI = ts.URL
+
+	// Download the JWKS
+	err = oidc.downloadJWKS()
+	if err != nil {
+		t.Fatalf("Failed to download JWKS: %v", err)
+	}
+
+	// Verify the public key was stored
+	if oidc.publicKeys["test-key"] == nil {
+		t.Error("Public key was not stored")
+	}
+}
+
+func TestOIDC_VerifyToken(t *testing.T) {
+	// Create a test RSA key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+		Domains: []string{"example.com"},
+	}
+	oidc, err := newOIDC(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create OIDC instance: %v", err)
+	}
+
+	// Store the public key
+	oidc.publicKeys["test-key"] = &privateKey.PublicKey
+
+	// Create a valid token
+	claims := jwt.MapClaims{
+		"iss": "https://accounts.google.com",
+		"aud": "dummy-client-id",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"hd":  "example.com",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign token: %v", err)
+	}
+
+	// Verify the token
+	valid, err := oidc.verifyToken(signedToken)
+	if err != nil {
+		t.Errorf("Unexpected error verifying valid token: %v", err)
+	}
+	if !valid {
+		t.Error("Valid token was not accepted")
+	}
+
+	// Test with invalid token
+	valid, err = oidc.verifyToken("invalid-token")
+	if err == nil {
+		t.Error("Expected error with invalid token")
+	}
+	if valid {
+		t.Error("Invalid token was accepted")
+	}
+
+  // Test with unknown domain
+	claims["hd"] = "unknown.com"
+	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	signedToken, err = token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign token: %v", err)
+	}
+
+	valid, err = oidc.verifyToken(signedToken)
+	if err == nil || err.Error() != "hosted domain unknown.com not in allowed domains" {
+		t.Errorf("Expected error 'hosted domain unknown.com not in allowed domains', got: %v", err)
+	}
+	if valid {
+		t.Error("Invalid token was accepted")
+	}
+
+	// Test with expired token
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	expiredToken, err := token.SignedString(privateKey)
+	if err != nil {
+		t.Fatalf("Failed to sign expired token: %v", err)
+	}
+
+	valid, err = oidc.verifyToken(expiredToken)
+	if err == nil {
+		t.Error("Expected error with expired token")
+	}
+	if valid {
+		t.Error("Expired token was accepted")
+	}
+}
+
+func TestOIDCProvider_Google(t *testing.T) {
+	// Create a test Google provider
+	cfg := &config.GoogleOIDCConfig{
+		ClientCredentialsFile: "testdata/google-client-dummy.json",
+		DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+	}
+	provider := NewGoogleProvider(cfg)
+
+	t.Run("GetOAuth2Config", func(t *testing.T) {
+		config, err := provider.GetOAuth2Config()
+		if err != nil {
+			t.Fatalf("Failed to get OAuth2 config: %v", err)
+		}
+		if config == nil {
+			t.Error("Expected non-nil OAuth2 config")
+		}
+	})
+
+	t.Run("GetDiscoveryURL", func(t *testing.T) {
+		url := provider.GetDiscoveryURL()
+		if url != cfg.GetDiscoveryURL() {
+			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+		}
+	})
+
+	t.Run("ValidateDomainClaims", func(t *testing.T) {
+		// Test valid domain
+		claims := jwt.MapClaims{
+			"hd": "example.com",
+		}
+		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err != nil {
+			t.Errorf("Expected no error for valid domain, got %v", err)
+		}
+
+		// Test invalid domain
+		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+		if err == nil {
+			t.Error("Expected error for invalid domain")
+		}
+
+		// Test missing hosted domain
+		claims = jwt.MapClaims{}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for missing hosted domain")
+		}
+
+		// Test empty hosted domain
+		claims = jwt.MapClaims{"hd": ""}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for empty hosted domain")
+		}
+	})
+}
+
+func TestOIDCProvider_Generic(t *testing.T) {
+	// Create a test Generic provider
+	cfg := &config.GenericOIDCConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:8080/auth/callback",
+		Scopes:       []string{"openid", "email"},
+		DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+	}
+	provider := NewGenericProvider(cfg)
+
+	t.Run("GetOAuth2Config", func(t *testing.T) {
+		config, err := provider.GetOAuth2Config()
+		if err != nil {
+			t.Fatalf("Failed to get OAuth2 config: %v", err)
+		}
+		if config == nil {
+			t.Error("Expected non-nil OAuth2 config")
+		}
+		if config.ClientID != cfg.ClientID {
+			t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
+		}
+		if config.ClientSecret != cfg.ClientSecret {
+			t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
+		}
+	})
+
+	t.Run("GetDiscoveryURL", func(t *testing.T) {
+		url := provider.GetDiscoveryURL()
+		if url != cfg.GetDiscoveryURL() {
+			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+		}
+	})
+
+	t.Run("ValidateDomainClaims", func(t *testing.T) {
+		// Test valid email domain
+		claims := jwt.MapClaims{
+			"email": "user@example.com",
+		}
+		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err != nil {
+			t.Errorf("Expected no error for valid email domain, got %v", err)
+		}
+
+		// Test invalid email domain
+		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+		if err == nil {
+			t.Error("Expected error for invalid email domain")
+		}
+
+		// Test missing email
+		claims = jwt.MapClaims{}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for missing email")
+		}
+
+		// Test empty email
+		claims = jwt.MapClaims{"email": ""}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for empty email")
+		}
+
+		// Test invalid email format
+		claims = jwt.MapClaims{"email": "invalid-email"}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for invalid email format")
+		}
+	})
+}
+
+func TestOIDC_ProviderSelection(t *testing.T) {
+	t.Run("Google Provider", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Google: &config.GoogleOIDCConfig{
+				ClientCredentialsFile: "testdata/google-client-dummy.json",
+				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+			},
+		}
+		oidc, err := newOIDC(cfg)
+		if err != nil {
+			t.Fatalf("Failed to create OIDC instance: %v", err)
+		}
+		if _, ok := oidc.provider.(*GoogleProvider); !ok {
+			t.Error("Expected GoogleProvider, got different provider type")
+		}
+	})
+
+	t.Run("Generic Provider", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Generic: &config.GenericOIDCConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost:8080/auth/callback",
+				Scopes:       []string{"openid", "email"},
+				DiscoveryURL: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+			},
+		}
+		oidc, err := newOIDC(cfg)
+		if err != nil {
+			t.Fatalf("Failed to create OIDC instance: %v", err)
+		}
+		if _, ok := oidc.provider.(*GenericProvider); !ok {
+			t.Error("Expected GenericProvider, got different provider type")
+		}
+	})
+
+	t.Run("Both Providers Configured", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Google: &config.GoogleOIDCConfig{
+				ClientCredentialsFile: "testdata/google-client-dummy.json",
+				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+			},
+			Generic: &config.GenericOIDCConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost:8080/auth/callback",
+				Scopes:       []string{"openid", "email"},
+				DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+			},
+		}
+		_, err := newOIDC(cfg)
+		if err == nil {
+			t.Error("Expected error when both providers are configured")
+		}
+	})
+}

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -204,7 +204,10 @@ func TestOIDC_DownloadJWKS(t *testing.T) {
 			},
 		}
 
-		json.NewEncoder(w).Encode(jwks)
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
 	}))
 	defer ts.Close()
 

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -583,11 +583,7 @@ func TestOIDC_UnauthenticatedRoutes(t *testing.T) {
 	req = httptest.NewRequest("GET", "/protected", nil)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusFound {
-		t.Errorf("Expected status code %d, got %d", http.StatusFound, rec.Code)
-	}
-	resp := rec.Result()
-	if location := resp.Header.Get("Location"); location != "/oidc/login" {
-		t.Errorf("Expected redirect to /oidc/login, got %s", location)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rec.Code)
 	}
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -404,10 +404,10 @@ func TestOIDCProvider_Generic(t *testing.T) {
 		if config == nil {
 			t.Error("Expected non-nil OAuth2 config")
 		}
-		if config.ClientID != cfg.ClientID {
+		if config != nil && config.ClientID != cfg.ClientID {
 			t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
 		}
-		if config.ClientSecret != cfg.ClientSecret {
+		if config != nil && config.ClientSecret != cfg.ClientSecret {
 			t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
 		}
 	})

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -95,7 +95,7 @@ func TestOIDC_Handlers(t *testing.T) {
 
 	t.Run("LoginHandler", func(t *testing.T) {
 		// Create a test request
-		req := httptest.NewRequest("GET", "/auth/login", nil)
+		req := httptest.NewRequest("GET", "/oidc/login", nil)
 		w := httptest.NewRecorder()
 
 		// Call the handler
@@ -133,7 +133,7 @@ func TestOIDC_Handlers(t *testing.T) {
 		}
 
 		// Create a test request with invalid state
-		req := httptest.NewRequest("GET", "/auth/callback?state=invalid&code=test-code", nil)
+		req := httptest.NewRequest("GET", "/oidc/callback?state=invalid&code=test-code", nil)
 		w := httptest.NewRecorder()
 		oidc.callbackHandler(w, req)
 		resp := w.Result()
@@ -149,7 +149,7 @@ func TestOIDC_Handlers(t *testing.T) {
 		}
 
 		// Create a test request with valid state but no code
-		req = httptest.NewRequest("GET", "/auth/callback?state="+state, nil)
+		req = httptest.NewRequest("GET", "/oidc/callback?state="+state, nil)
 		w = httptest.NewRecorder()
 		oidc.callbackHandler(w, req)
 		resp = w.Result()
@@ -166,33 +166,39 @@ func TestOIDC_Handlers(t *testing.T) {
 	})
 
 	t.Run("LogoutHandler", func(t *testing.T) {
-		// Create a test request
-		req := httptest.NewRequest("GET", "/auth/logout", nil)
-		w := httptest.NewRecorder()
+		testPaths := []string{"/oidc/logout", "/logout"}
 
-		// Call the handler
-		oidc.logoutHandler(w, req)
+		for _, path := range testPaths {
+			t.Run(path, func(t *testing.T) {
+				// Create a test request
+				req := httptest.NewRequest("GET", path, nil)
+				w := httptest.NewRecorder()
 
-		// Check the response
-		resp := w.Result()
-		if resp.StatusCode != http.StatusFound {
-			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-		}
+				// Call the handler
+				oidc.logoutHandler(w, req)
 
-		// Verify the cookie is cleared
-		cookies := resp.Cookies()
-		if len(cookies) != 1 {
-			t.Errorf("Expected 1 cookie, got %d", len(cookies))
-		}
-		cookie := cookies[0]
-		if cookie.Name != sessionCookieName {
-			t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
-		}
-		if cookie.Value != "" {
-			t.Error("Expected empty cookie value")
-		}
-		if cookie.MaxAge != -1 {
-			t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+				// Check the response
+				resp := w.Result()
+				if resp.StatusCode != http.StatusFound {
+					t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+				}
+
+				// Verify the cookie is cleared
+				cookies := resp.Cookies()
+				if len(cookies) != 1 {
+					t.Errorf("Expected 1 cookie, got %d", len(cookies))
+				}
+				cookie := cookies[0]
+				if cookie.Name != sessionCookieName {
+					t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
+				}
+				if cookie.Value != "" {
+					t.Error("Expected empty cookie value")
+				}
+				if cookie.MaxAge != -1 {
+					t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+				}
+			})
 		}
 	})
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -581,7 +581,7 @@ func TestOIDC_UnauthenticatedRoutes(t *testing.T) {
 		t.Errorf("Expected status code %d, got %d", http.StatusFound, rec.Code)
 	}
 	resp := rec.Result()
-	if location := resp.Header.Get("Location"); location != "/auth/login" {
-		t.Errorf("Expected redirect to /auth/login, got %s", location)
+	if location := resp.Header.Get("Location"); location != "/oidc/login" {
+		t.Errorf("Expected redirect to /oidc/login, got %s", location)
 	}
 }

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -111,6 +111,7 @@ func (s *Server) Run() error {
 		s.engine = protectedMux
 	} else {
 		log.Error(err, "Failed to require OIDC authentication")
+		return err
 	}
 
 	serverConfig := s.serverConfig

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -2,11 +2,9 @@ package server
 
 import (
 	"connectrpc.com/connect"
-	connectcors "connectrpc.com/cors"
 	"connectrpc.com/grpchealth"
 	"github.com/jlewi/cloud-assistant/app/pkg/ai"
 	"github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
-	"github.com/rs/cors"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 
@@ -37,7 +35,7 @@ type Server struct {
 	telemetry        *config.TelemetryConfig
 	serverConfig     *config.AssistantServerConfig
 	hServer          *http.Server
-	engine           *http.ServeMux
+	engine           http.Handler
 	shutdownComplete chan bool
 	runner           *Runner
 	agent            *ai.Agent
@@ -106,14 +104,6 @@ func (s *Server) Run() error {
 		return errors.Wrapf(err, "Failed to register services")
 	}
 
-	// Require OIDC auth if configured
-	if protectedMux, err := RequireOIDC(s.serverConfig.OIDC, s.engine); err == nil {
-		s.engine = protectedMux
-	} else {
-		log.Error(err, "Failed to require OIDC authentication")
-		return err
-	}
-
 	serverConfig := s.serverConfig
 	if serverConfig == nil {
 		serverConfig = &config.AssistantServerConfig{}
@@ -160,28 +150,14 @@ func (s *Server) Run() error {
 	return nil
 }
 
-// handlerWithCORS adds CORS support to a Connect HTTP handler.
-func (s *Server) handlerWithCORS(connectHandler http.Handler) http.Handler {
-	log := zapr.NewLogger(zap.L())
-	origins := s.serverConfig.CorsOrigins
-	if len(origins) == 0 {
-		log.Info("No additional CORS origins specified")
-		return connectHandler
-	}
-	log.Info("Adding CORS support", "origins", origins)
-	c := cors.New(cors.Options{
-		AllowedOrigins: origins,
-		AllowedMethods: connectcors.AllowedMethods(),
-		AllowedHeaders: connectcors.AllowedHeaders(),
-		ExposedHeaders: connectcors.ExposedHeaders(),
-		MaxAge:         7200, // 2 hours in seconds
-	})
-	return c.Handler(connectHandler)
-}
-
 func (s *Server) registerServices() error {
 	log := zapr.NewLogger(zap.L())
-	mux := http.NewServeMux()
+
+	// Create auth mux
+	mux, err := NewAuthMux(s.serverConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create auth mux")
+	}
 
 	// Create the OTEL interceptor
 	otelInterceptor, err := otelconnect.NewInterceptor()
@@ -191,10 +167,25 @@ func (s *Server) registerServices() error {
 
 	interceptors := []connect.Interceptor{otelInterceptor}
 
+	origins := s.serverConfig.CorsOrigins
+	if len(origins) == 0 {
+		log.Info("No additional CORS origins specified for protected routes")
+	} else {
+		log.Info("Adding CORS support for protected routes", "origins", origins)
+	}
+
+	// Register auth routes if OIDC is configured
+	if s.serverConfig.OIDC != nil {
+		if err := RegisterAuthRoutes(s.serverConfig.OIDC, mux); err != nil {
+			return errors.Wrapf(err, "Failed to register auth routes")
+		}
+	}
+
 	if s.agent != nil {
 		aiSvcPath, aiSvcHandler := cassieconnect.NewBlocksServiceHandler(s.agent, connect.WithInterceptors(interceptors...))
 		log.Info("Setting up AI service", "path", aiSvcPath)
-		mux.Handle(aiSvcPath, s.handlerWithCORS(aiSvcHandler))
+		// Protect the AI service
+		mux.HandleProtected(aiSvcPath, aiSvcHandler)
 	} else {
 		log.Info("Agent is nil; AI service is disabled")
 	}
@@ -203,17 +194,25 @@ func (s *Server) registerServices() error {
 		sHandler := &WebSocketHandler{
 			runner: s.runner,
 		}
-		// Mount other Connect handlers
-		mux.Handle("/ws", http.HandlerFunc(sHandler.Handler))
-
+		// Protect the WebSocket handler
+		mux.HandleProtected("/ws", http.HandlerFunc(sHandler.Handler))
 		log.Info("Setting up runner service", "path", "/ws")
 	}
+
+	// Health check should be public
 	checker := grpchealth.NewStaticChecker()
 	mux.Handle(grpchealth.NewHandler(checker))
 
+	// Handle the single page app and assets unprotected
+	singlePageApp, err := s.singlePageAppHandler()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to serve single page app")
+	}
+	mux.Handle("/", singlePageApp)
+
 	s.engine = mux
 
-	return s.serveSinglePageApp()
+	return nil
 }
 
 func (s *Server) shutdown() {

--- a/app/pkg/server/testdata/google-client-dummy.json
+++ b/app/pkg/server/testdata/google-client-dummy.json
@@ -1,0 +1,13 @@
+{
+  "web": {
+    "client_id": "dummy-client-id",
+    "project_id": "dummy-project-id",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://oauth2.googleapis.com/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_secret": "dummy-client-secret",
+    "redirect_uris": [
+      "http://localhost:8080/auth/callback"
+    ]
+  }
+}

--- a/app/pkg/server/testdata/google-client-dummy.json
+++ b/app/pkg/server/testdata/google-client-dummy.json
@@ -7,7 +7,7 @@
     "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
     "client_secret": "dummy-client-secret",
     "redirect_uris": [
-      "http://localhost:8080/auth/callback"
+      "http://localhost:8080/oidc/callback"
     ]
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -6,6 +6,10 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // DONT CHANGE THIS LINE, it's replaced by the server
+      window.__INITIAL_STATE__ = { requireAuth: false }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -57,12 +57,12 @@ function App({ initialState = {} }: AppProps) {
                     }
                   />
                   <Route
-                    path="/auth/*"
+                    path="/oidc/*"
                     element={
                       <Layout
                         middle={
                           <div>
-                            Auth routes are exclusively handled by the server.
+                            OIDC routes are exclusively handled by the server.
                           </div>
                         }
                       />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import openaiLogo from './assets/openai.svg'
 import Actions from './components/Actions/Actions'
 import Chat from './components/Chat/Chat'
 import FileViewer from './components/Files/Viewer'
+import Login from './components/Login/Login'
 import NotFound from './components/NotFound'
 import Settings from './components/Settings/Settings'
 import { AgentClientProvider } from './contexts/AgentContext'
@@ -15,7 +16,13 @@ import { BlockProvider } from './contexts/BlockContext'
 import { SettingsProvider } from './contexts/SettingsContext'
 import Layout from './layout'
 
-function App() {
+export interface AppProps {
+  initialState?: {
+    requireAuth?: boolean
+  }
+}
+
+function App({ initialState = {} }: AppProps) {
   return (
     <>
       <Theme accentColor="gray" scaling="110%" radius="small">
@@ -24,7 +31,7 @@ function App() {
           <meta name="description" content="An AI Assistant For Your Cloud" />
           <link rel="icon" href={openaiLogo} />
         </Helmet>
-        <SettingsProvider>
+        <SettingsProvider requireAuth={initialState.requireAuth}>
           <AgentClientProvider>
             <BlockProvider>
               <BrowserRouter>
@@ -49,6 +56,19 @@ function App() {
                       />
                     }
                   />
+                  <Route
+                    path="/auth/*"
+                    element={
+                      <Layout
+                        middle={
+                          <div>
+                            Auth routes are exclusively handled by the server.
+                          </div>
+                        }
+                      />
+                    }
+                  />
+                  <Route path="/login" element={<Layout left={<Login />} />} />
                   <Route path="*" element={<Layout left={<NotFound />} />} />
                 </Routes>
               </BrowserRouter>

--- a/web/src/components/Login/Login.tsx
+++ b/web/src/components/Login/Login.tsx
@@ -1,0 +1,28 @@
+import { useSearchParams } from 'react-router-dom'
+
+import { Button, Callout } from '@radix-ui/themes'
+
+export default function Login() {
+  const [searchParams] = useSearchParams()
+  const error = searchParams.get('error')
+  const errorDescription = searchParams.get('error_description')
+
+  const handleLogin = () => {
+    // Navigate to /oidc/login to trigger OIDC-flow
+    window.location.href = '/oidc/login'
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4">
+      {error && (
+        <Callout.Root color="red">
+          <Callout.Text className="font-bold">Error: "{error}"</Callout.Text>
+          {errorDescription && <Callout.Text>{errorDescription}</Callout.Text>}
+        </Callout.Root>
+      )}
+      <Button size="4" onClick={handleLogin} className="cursor-pointer">
+        Login
+      </Button>
+    </div>
+  )
+}

--- a/web/src/components/Runme/Console.tsx
+++ b/web/src/components/Runme/Console.tsx
@@ -165,6 +165,16 @@ function Console({
   useEffect(() => {
     socket = createWebSocket(settings.runnerEndpoint)
 
+    socket.onclose = (e: CloseEvent) => {
+      if (e.code <= 1000) {
+        return
+      }
+
+      // TODO: This is a temporary fix to redirect to the login on any error
+      const error = `WebSocket closed with code ${e.code}`
+      window.location.href = `/login?error=${encodeURIComponent(error)}`
+    }
+
     socket.onmessage = (event) => {
       if (typeof event.data !== 'string') {
         console.warn('Unexpected WebSocket message type:', typeof event.data)

--- a/web/src/contexts/BlockContext.tsx
+++ b/web/src/contexts/BlockContext.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, createContext, useContext, useMemo, useState } from 'react'
 
 import { clone, create } from '@bufbuild/protobuf'
+import { ConnectError } from '@connectrpc/connect'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
@@ -51,6 +52,15 @@ export const useBlock = () => {
 interface BlockState {
   blocks: Record<string, Block>
   positions: string[]
+}
+
+const handleConnectError = (error: unknown) => {
+  console.error(error)
+  const connectErr = ConnectError.from(error)
+  // todo: This code is always internal error, let's figure out why later
+  if (connectErr.code) {
+    window.location.href = `/login?error=${encodeURIComponent(connectErr.name)}&error_description=${encodeURIComponent(connectErr.rawMessage)}`
+  }
 }
 
 export const BlockProvider = ({ children }: { children: ReactNode }) => {
@@ -129,7 +139,7 @@ export const BlockProvider = ({ children }: { children: ReactNode }) => {
         setPreviousResponseId(r.responseId)
       }
     } catch (e) {
-      console.error(e)
+      handleConnectError(e)
     } finally {
       setIsTyping(false)
       setIsInputDisabled(false)

--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -9,26 +9,26 @@ import {
 interface Settings {
   agentEndpoint: string
   runnerEndpoint: string
+  requireAuth: boolean
 }
 
 interface SettingsContextType {
-  getDefaultSettings: () => Settings
   settings: Settings
   updateSettings: (newSettings: Partial<Settings>) => void
+  getDefaultSettings: () => Settings
 }
 
-const getDefaultSettings = (): Settings => {
-  return {
-    agentEndpoint:
-      window.location.hostname === 'localhost'
-        ? 'http://localhost:8080'
-        : window.location.origin,
-    runnerEndpoint:
-      window.location.hostname === 'localhost'
-        ? 'ws://localhost:8080/ws'
-        : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`,
-  }
-}
+const getDefaultSettings = (): Settings => ({
+  agentEndpoint:
+    window.location.protocol === 'https:'
+      ? 'https://agent.example.com'
+      : 'http://agent.example.com',
+  runnerEndpoint:
+    window.location.protocol === 'https:'
+      ? 'wss://runner.example.com'
+      : 'ws://runner.example.com',
+  requireAuth: false,
+})
 
 const SettingsContext = createContext<SettingsContextType | undefined>(
   undefined
@@ -43,12 +43,28 @@ export const useSettings = () => {
   return context
 }
 
-export const SettingsProvider = ({ children }: { children: ReactNode }) => {
+interface SettingsProviderProps {
+  children: ReactNode
+  requireAuth?: boolean
+}
+
+export const SettingsProvider = ({
+  children,
+  requireAuth,
+}: SettingsProviderProps) => {
   const [settings, setSettings] = useState<Settings>(() => {
     const savedSettings = localStorage.getItem('cloudAssistantSettings')
-    return savedSettings
-      ? { ...getDefaultSettings(), ...JSON.parse(savedSettings) }
-      : getDefaultSettings()
+    const defaultSettings = getDefaultSettings()
+    const mergedSettings = savedSettings
+      ? { ...defaultSettings, ...JSON.parse(savedSettings) }
+      : defaultSettings
+
+    // Override requireAuth if provided
+    if (requireAuth !== undefined) {
+      mergedSettings.requireAuth = requireAuth
+    }
+
+    return mergedSettings
   })
 
   useEffect(() => {

--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -20,13 +20,13 @@ interface SettingsContextType {
 
 const getDefaultSettings = (): Settings => ({
   agentEndpoint:
-    window.location.protocol === 'https:'
-      ? 'https://agent.example.com'
-      : 'http://agent.example.com',
+    window.location.hostname === 'localhost'
+      ? 'http://localhost:8080'
+      : window.location.origin,
   runnerEndpoint:
-    window.location.protocol === 'https:'
-      ? 'wss://runner.example.com'
-      : 'ws://runner.example.com',
+    window.location.hostname === 'localhost'
+      ? 'ws://localhost:8080/ws'
+      : `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws`,
   requireAuth: false,
 })
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,18 @@
 import { createRoot } from 'react-dom/client'
 
-import App from './App.tsx'
+import App, { AppProps } from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById('root')!).render(<App />)
+// Define the type for the window object with initial state
+declare global {
+  interface Window {
+    __INITIAL_STATE__?: AppProps['initialState']
+  }
+}
+
+// Read initial state from window object
+const initialState = window.__INITIAL_STATE__ || {}
+
+createRoot(document.getElementById('root')!).render(
+  <App initialState={initialState} />
+)


### PR DESCRIPTION
This will allow any generic OIDC, not just Google, to be configured. Successfully tested it with Azure Entra ID (video below).

The F/E needs to be wired up for better error/feedback, etc. Also, when API calls are rejected due to lack of auth, we should forward them to a login page and not silently ignore them.

Also added some tests because OIDC can be finicky.

https://github.com/user-attachments/assets/f3fce972-a760-49b0-9a14-0d52b8bf0c9a