### PR TITLE
AuthZ with OIDC - IAM Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ assistantServer:
 ./app/.build/cas config set assistantServer.staticAssets=$(PWD)/web/dist
 ```
 
+### Setting Up Auth Using Microsoft Entra ID
+
+The OIDC discovery URL will be
+
+```
+ https://login.microsoftonline.com/${TENANT_ID}/v2.0/.well-known/openid-configuration
+```
+
+Where ${TENANT_ID} is the ID of your Microsoft Entra ID tenant.
+
 ### Build the static assets
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ assistantServer:
                 - "openid"
                 - "email"
             issuer: https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 # TODO: change this to your own tenant ID
-        domains:
-            - "evilcorp.com"
-            - "myemail.com"
         forceApproval: false # helpful for troubleshooting issues with OIDC
 ```
 
@@ -60,16 +57,6 @@ assistantServer:
  cd ${REPOSITORY}
 ./app/.build/cas config set assistantServer.staticAssets=$(PWD)/web/dist
 ```
-
-### Setting Up Auth Using Microsoft Entra ID
-
-The OIDC discovery URL will be
-
-```
- https://login.microsoftonline.com/${TENANT_ID}/v2.0/.well-known/openid-configuration
-```
-
-Where ${TENANT_ID} is the ID of your Microsoft Entra ID tenant.
 
 ### Build the static assets
 

--- a/app/api/iam.go
+++ b/app/api/iam.go
@@ -1,0 +1,32 @@
+package api
+
+const (
+	// RunnerUserRole is the role for the runner user.
+	RunnerUserRole = "role/runner.user"
+
+	// AgentUserRole is the role for the agent user.
+	AgentUserRole = "role/agent.user"
+)
+
+// IAMPolicy is a policy that defines the access control for the service.
+type IAMPolicy struct {
+	// Bindings is a list of bindings that define the access control for the service.
+	Bindings []IAMBinding `json:"bindings" yaml:"bindings"`
+}
+
+// IAMBinding is a binding of identities to roles.
+// N.B. Currently we don't have any roles defined so this is just a list of members.
+type IAMBinding struct {
+	// Members is a list of members that are allowed to access the service
+	Members []Member `json:"members" yaml:"members"`
+
+	// Role is the role for the members
+	Role string `json:"role" yaml:"role"`
+}
+
+type Member struct {
+	// Name is the name of the member. e.g. jlewi@acme.com
+	// N.B. In the future we could add a kind field to indicate what type of member it is
+	// (e.g.domain, serviceaccount, group).
+	Name string `json:"name" yaml:"name"`
+}

--- a/app/cmd/serve.go
+++ b/app/cmd/serve.go
@@ -47,6 +47,7 @@ func NewServeCmd() *cobra.Command {
 			serverOptions := &server.Options{
 				Telemetry: app.Config.Telemetry,
 				Server:    app.Config.AssistantServer,
+				IAMPolicy: app.Config.IAMPolicy,
 			}
 			s, err := server.NewServer(*serverOptions, agent)
 			if err != nil {

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -57,6 +57,10 @@ type Config struct {
 
 	CloudAssistant  *CloudAssistantConfig  `json:"cloudAssistant,omitempty" yaml:"cloudAssistant,omitempty"`
 	AssistantServer *AssistantServerConfig `json:"assistantServer,omitempty" yaml:"assistantServer,omitempty"`
+
+	// IAMPolicy is the IAM policy for the service. It only matters if OIDC is enabled in the AssistantServerConfig.
+	IAMPolicy *api.IAMPolicy `json:"iamPolicy,omitempty" yaml:"iamPolicy,omitempty"`
+
 	// configFile is the configuration file used
 	configFile string
 }

--- a/app/pkg/iam/checker.go
+++ b/app/pkg/iam/checker.go
@@ -1,0 +1,107 @@
+package iam
+
+import (
+	"github.com/jlewi/cloud-assistant/app/api"
+	"github.com/pkg/errors"
+	"strings"
+)
+
+type Checker interface {
+	Check(principal string, role string) bool
+}
+
+// PolicyChecker enforces IAMPolicies. It checks if a user has the required permissions to perform an action.
+type PolicyChecker struct {
+	policy api.IAMPolicy
+
+	// Create a map from roles to members
+	roles map[string]map[string]bool
+}
+
+// NewChecker creates a new IAM policy checker.
+func NewChecker(policy api.IAMPolicy) (*PolicyChecker, error) {
+	// Validate the policy
+	if isValid, msg := IsValidPolicy(policy); !isValid {
+		return nil, errors.New(msg)
+	}
+
+	c := &PolicyChecker{
+		policy: policy,
+		roles:  make(map[string]map[string]bool),
+	}
+
+	// Cache the roles
+	for _, binding := range policy.Bindings {
+		if _, ok := c.roles[binding.Role]; !ok {
+			c.roles[binding.Role] = make(map[string]bool)
+		}
+
+		for _, member := range binding.Members {
+			c.roles[binding.Role][member.Name] = true
+		}
+	}
+
+	return c, nil
+}
+
+// Check returns true if and only if the principal has the given role in the IAM policy.
+func (c *PolicyChecker) Check(principal string, role string) bool {
+	members, ok := c.roles[role]
+	if !ok {
+		return false
+	}
+
+	if _, ok := members[principal]; ok {
+		return true
+	} else {
+		return false
+	}
+}
+
+// IsValidPolicy checks if the IAM policy is valid. If its not it returns a string with a human readable
+// message about the violations
+func IsValidPolicy(policy api.IAMPolicy) (bool, string) {
+
+	allowedRoles := map[string]bool{api.RunnerUserRole: true, api.AgentUserRole: true}
+	roleNames := []string{api.RunnerUserRole, api.AgentUserRole}
+	violations := func() []string {
+		violations := make([]string, 0, 10)
+		// Check if the policy is valid
+		if len(policy.Bindings) == 0 {
+			violations = append(violations, "policy must have at least one binding")
+			return violations
+		}
+
+		for _, binding := range policy.Bindings {
+			if len(binding.Members) == 0 {
+				violations = append(violations, "binding must have at least one member")
+			}
+
+			if binding.Role == "" {
+				violations = append(violations, "binding must have a role")
+			}
+
+			if _, ok := allowedRoles[binding.Role]; !ok {
+				violations = append(violations, "binding role must be one of: %s", strings.Join(roleNames, ","))
+			}
+		}
+
+		return violations
+	}()
+
+	message := ""
+	if len(violations) > 0 {
+		message = "IAM policy is invalid. Violations: " + strings.Join(violations, ", ")
+		return false, message
+	}
+
+	return true, message
+}
+
+// AllowAllChecker is a no auth checker that allows all requests.
+type AllowAllChecker struct {
+}
+
+func (c *AllowAllChecker) Check(principal string, role string) bool {
+	return true
+}

--- a/app/pkg/iam/checker.go
+++ b/app/pkg/iam/checker.go
@@ -1,9 +1,10 @@
 package iam
 
 import (
+	"strings"
+
 	"github.com/jlewi/cloud-assistant/app/api"
 	"github.com/pkg/errors"
-	"strings"
 )
 
 type Checker interface {

--- a/app/pkg/iam/checker_test.go
+++ b/app/pkg/iam/checker_test.go
@@ -1,0 +1,64 @@
+package iam
+
+import (
+	"testing"
+
+	"github.com/jlewi/cloud-assistant/app/api"
+)
+
+func TestChecker_Check(t *testing.T) {
+	testCases := []struct {
+		name      string
+		principal string
+		role      string
+		policy    api.IAMPolicy
+		expected  bool
+	}{
+		{
+			name:      "User has role",
+			principal: "user1",
+			role:      api.RunnerUserRole,
+			policy: api.IAMPolicy{
+				Bindings: []api.IAMBinding{
+					{
+						Role: api.RunnerUserRole,
+						Members: []api.Member{
+							{Name: "user1"},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "User doesn't have role",
+			principal: "user2",
+			role:      api.RunnerUserRole,
+			policy: api.IAMPolicy{
+				Bindings: []api.IAMBinding{
+					{
+						Role: api.RunnerUserRole,
+						Members: []api.Member{
+							{Name: "user1"},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			checker, err := NewChecker(tc.policy)
+			if err != nil {
+				t.Fatalf("failed to create checker: %v", err)
+			}
+
+			result := checker.Check(tc.principal, tc.role)
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -1,133 +1,133 @@
 package server
 
 import (
-	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"math/big"
-	"net/http"
-	"net/url"
-	"os"
-	"slices"
-	"strings"
-	"sync"
-	"time"
+  "context"
+  "crypto/rand"
+  "crypto/rsa"
+  "encoding/base64"
+  "encoding/json"
+  "fmt"
+  "math/big"
+  "net/http"
+  "net/url"
+  "os"
+  "slices"
+  "strings"
+  "sync"
+  "time"
 
-	"github.com/jlewi/cloud-assistant/app/pkg/iam"
-	"github.com/jlewi/cloud-assistant/app/pkg/logs"
+  "github.com/jlewi/cloud-assistant/app/pkg/iam"
+  "github.com/jlewi/cloud-assistant/app/pkg/logs"
 
-	connectcors "connectrpc.com/cors"
-	"github.com/go-logr/zapr"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/jlewi/cloud-assistant/app/pkg/config"
-	"github.com/pkg/errors"
-	"github.com/rs/cors"
-	"go.uber.org/zap"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
+  connectcors "connectrpc.com/cors"
+  "github.com/go-logr/zapr"
+  "github.com/golang-jwt/jwt/v5"
+  "github.com/jlewi/cloud-assistant/app/pkg/config"
+  "github.com/pkg/errors"
+  "github.com/rs/cors"
+  "go.uber.org/zap"
+  "golang.org/x/oauth2"
+  "golang.org/x/oauth2/google"
 )
 
 const (
-	oidcPathPrefix    = "/oidc"
-	sessionCookieName = "cassie-session"
-	stateLength       = 32
-	IDTokenKey        = "idToken"
+  oidcPathPrefix    = "/oidc"
+  sessionCookieName = "cassie-session"
+  stateLength       = 32
+  IDTokenKey        = "idToken"
 )
 
 // OIDC handles OAuth2 authentication setup and management
 type OIDC struct {
-	config     *config.OIDCConfig
-	oauth2     *oauth2.Config
-	publicKeys map[string]*rsa.PublicKey
-	discovery  *openIDDiscovery
-	state      *stateManager
-	provider   OIDCProvider
+  config     *config.OIDCConfig
+  oauth2     *oauth2.Config
+  publicKeys map[string]*rsa.PublicKey
+  discovery  *openIDDiscovery
+  state      *stateManager
+  provider   OIDCProvider
 }
 
 // newOIDC creates a new OIDC
 func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
-	if cfg == nil {
-		return nil, nil
-	}
+  if cfg == nil {
+    return nil, nil
+  }
 
-	// Check that only one provider is configured
-	if cfg.Google != nil && cfg.Generic != nil {
-		return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
-	}
+  // Check that only one provider is configured
+  if cfg.Google != nil && cfg.Generic != nil {
+    return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
+  }
 
-	if cfg.Google == nil && cfg.Generic == nil {
-		return nil, nil
-	}
+  if cfg.Google == nil && cfg.Generic == nil {
+    return nil, nil
+  }
 
-	var provider OIDCProvider
-	if cfg.Google != nil {
-		provider = NewGoogleProvider(cfg.Google)
-	} else {
-		provider = NewGenericProvider(cfg.Generic)
-	}
+  var provider OIDCProvider
+  if cfg.Google != nil {
+    provider = NewGoogleProvider(cfg.Google)
+  } else {
+    provider = NewGenericProvider(cfg.Generic)
+  }
 
-	oauth2Config, err := provider.GetOAuth2Config()
-	if err != nil {
-		return nil, err
-	}
+  oauth2Config, err := provider.GetOAuth2Config()
+  if err != nil {
+    return nil, err
+  }
 
-	discoveryURL := provider.GetDiscoveryURL()
+  discoveryURL := provider.GetDiscoveryURL()
 
-	// Fetch the OpenID configuration
-	resp, err := http.Get(discoveryURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			zap.L().Error("failed to close response body", zap.Error(err))
-		}
-	}()
+  // Fetch the OpenID configuration
+  resp, err := http.Get(discoveryURL)
+  if err != nil {
+    return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
+  }
+  defer func() {
+    if err := resp.Body.Close(); err != nil {
+      zap.L().Error("failed to close response body", zap.Error(err))
+    }
+  }()
 
-	var discovery openIDDiscovery
-	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
-		return nil, errors.Wrap(err, "failed to decode OpenID configuration")
-	}
+  var discovery openIDDiscovery
+  if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+    return nil, errors.Wrap(err, "failed to decode OpenID configuration")
+  }
 
-	// Update endpoints from discovery document
-	oauth2Config.Endpoint = oauth2.Endpoint{
-		AuthURL:  discovery.AuthURL,
-		TokenURL: discovery.TokenURL,
-	}
+  // Update endpoints from discovery document
+  oauth2Config.Endpoint = oauth2.Endpoint{
+    AuthURL:  discovery.AuthURL,
+    TokenURL: discovery.TokenURL,
+  }
 
-	// If the generic provider is configured with an issuer, use it
-	if cfg.Generic != nil && cfg.Generic.Issuer != "" {
-		discovery.Issuer = cfg.Generic.Issuer
-	}
+  // If the generic provider is configured with an issuer, use it
+  if cfg.Generic != nil && cfg.Generic.Issuer != "" {
+    discovery.Issuer = cfg.Generic.Issuer
+  }
 
-	// Initialize OIDC
-	oidc := &OIDC{
-		config:     cfg,
-		oauth2:     oauth2Config,
-		publicKeys: make(map[string]*rsa.PublicKey),
-		discovery:  &discovery,
-		state:      newStateManager(10 * time.Minute),
-		provider:   provider,
-	}
+  // Initialize OIDC
+  oidc := &OIDC{
+    config:     cfg,
+    oauth2:     oauth2Config,
+    publicKeys: make(map[string]*rsa.PublicKey),
+    discovery:  &discovery,
+    state:      newStateManager(10 * time.Minute),
+    provider:   provider,
+  }
 
-	// Download JWKS for signature verification
-	if err := oidc.downloadJWKS(); err != nil {
-		return nil, errors.Wrapf(err, "Failed to download JWKS")
-	}
+  // Download JWKS for signature verification
+  if err := oidc.downloadJWKS(); err != nil {
+    return nil, errors.Wrapf(err, "Failed to download JWKS")
+  }
 
-	// Start a goroutine to clean up expired states
-	go func() {
-		ticker := time.NewTicker(oidc.state.stateExpiration / 2)
-		defer ticker.Stop()
-		for range ticker.C {
-			oidc.state.cleanupExpiredStates()
-		}
-	}()
+  // Start a goroutine to clean up expired states
+  go func() {
+    ticker := time.NewTicker(oidc.state.stateExpiration / 2)
+    defer ticker.Stop()
+    for range ticker.C {
+      oidc.state.cleanupExpiredStates()
+    }
+  }()
 
-	return oidc, nil
+  return oidc, nil
 }
 
 // downloadJWKS downloads the JSON Web Key Set (JWKS) from Google's OAuth2 provider.
@@ -136,597 +136,601 @@ func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
 // This allows the application to verify tokens offline without contacting Google's servers
 // for each verification request.
 func (o *OIDC) downloadJWKS() error {
-	// Fetch the JWKS from the URI specified in the discovery document
-	resp, err := http.Get(o.discovery.JWKSURI)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			zap.L().Error("failed to close response body", zap.Error(err))
-		}
-	}()
+  // Fetch the JWKS from the URI specified in the discovery document
+  resp, err := http.Get(o.discovery.JWKSURI)
+  if err != nil {
+    return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
+  }
+  defer func() {
+    if err := resp.Body.Close(); err != nil {
+      zap.L().Error("failed to close response body", zap.Error(err))
+    }
+  }()
 
-	// Parse the JWKS into our structured format
-	var jwks jwks
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		return errors.Wrapf(err, "Failed to parse JWKS response")
-	}
+  // Parse the JWKS into our structured format
+  var jwks jwks
+  if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+    return errors.Wrapf(err, "Failed to parse JWKS response")
+  }
 
-	// Convert each key to RSA public key and store in the map
-	for _, key := range jwks.Keys {
-		// Convert the modulus and exponent from base64url to *rsa.PublicKey
-		n, err := base64.RawURLEncoding.DecodeString(key.N)
-		if err != nil {
-			return errors.Wrap(err, "failed to decode modulus")
-		}
+  // Convert each key to RSA public key and store in the map
+  for _, key := range jwks.Keys {
+    // Convert the modulus and exponent from base64url to *rsa.PublicKey
+    n, err := base64.RawURLEncoding.DecodeString(key.N)
+    if err != nil {
+      return errors.Wrap(err, "failed to decode modulus")
+    }
 
-		e, err := base64.RawURLEncoding.DecodeString(key.E)
-		if err != nil {
-			return errors.Wrap(err, "failed to decode exponent")
-		}
+    e, err := base64.RawURLEncoding.DecodeString(key.E)
+    if err != nil {
+      return errors.Wrap(err, "failed to decode exponent")
+    }
 
-		// Convert the modulus to a big integer
-		modulus := new(big.Int).SetBytes(n)
+    // Convert the modulus to a big integer
+    modulus := new(big.Int).SetBytes(n)
 
-		// Convert the exponent to an integer
-		var exponent int
-		if len(e) < 4 {
-			for i := range e {
-				exponent = exponent<<8 + int(e[i])
-			}
-		} else {
-			return errors.New("exponent too large")
-		}
+    // Convert the exponent to an integer
+    var exponent int
+    if len(e) < 4 {
+      for i := range e {
+        exponent = exponent<<8 + int(e[i])
+      }
+    } else {
+      return errors.New("exponent too large")
+    }
 
-		// Create the RSA public key
-		publicKey := &rsa.PublicKey{
-			N: modulus,
-			E: exponent,
-		}
+    // Create the RSA public key
+    publicKey := &rsa.PublicKey{
+      N: modulus,
+      E: exponent,
+    }
 
-		// Store the public key in the map using the kid as the key
-		o.publicKeys[key.Kid] = publicKey
-	}
+    // Store the public key in the map using the kid as the key
+    o.publicKeys[key.Kid] = publicKey
+  }
 
-	return nil
+  return nil
 }
 
 // verifyToken verifies the JWT token and returns whether it's valid and any error encountered
 // result is nil if its an invalid token and non-nil if its valid
 func (o *OIDC) verifyToken(idToken string) (*jwt.Token, error) {
-	// Verify the token signature using JWKS
-	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
-		// Verify the signing method is what we expect
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
+  // Verify the token signature using JWKS
+  token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+    // Verify the signing method is what we expect
+    if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+      return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+    }
 
-		// Get the key ID from the token header
-		kid, ok := token.Header["kid"].(string)
-		if !ok {
-			return nil, errors.New("kid header not found in token")
-		}
+    // Get the key ID from the token header
+    kid, ok := token.Header["kid"].(string)
+    if !ok {
+      return nil, errors.New("kid header not found in token")
+    }
 
-		// Get the public key from our map
-		publicKey, ok := o.publicKeys[kid]
-		if !ok {
-			return nil, errors.New("unable to find appropriate key")
-		}
+    // Get the public key from our map
+    publicKey, ok := o.publicKeys[kid]
+    if !ok {
+      return nil, errors.New("unable to find appropriate key")
+    }
 
-		return publicKey, nil
-	})
+    return publicKey, nil
+  })
 
-	if err != nil || !token.Valid {
-		return nil, fmt.Errorf("invalid token signature: %v", err)
-	}
+  if err != nil || !token.Valid {
+    return nil, fmt.Errorf("invalid token signature: %v", err)
+  }
 
-	// Get the claims from the token
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, errors.New("failed to get claims from token")
-	}
+  // Get the claims from the token
+  claims, ok := token.Claims.(jwt.MapClaims)
+  if !ok {
+    return nil, errors.New("failed to get claims from token")
+  }
 
-	// Verify expiration
-	exp, err := claims.GetExpirationTime()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
-	}
-	if time.Now().After(exp.Time) {
-		return nil, errors.New("token expired")
-	}
+  // Verify expiration
+  exp, err := claims.GetExpirationTime()
+  if err != nil {
+    return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
+  }
+  if time.Now().After(exp.Time) {
+    return nil, errors.New("token expired")
+  }
 
-	// Verify issuer
-	iss, err := claims.GetIssuer()
-	if err != nil || iss != o.discovery.Issuer {
-		return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
-	}
+  // Verify issuer
+  iss, err := claims.GetIssuer()
+  if err != nil || iss != o.discovery.Issuer {
+    return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
+  }
 
-	// Verify audience matches our client ID
-	aud, err := claims.GetAudience()
-	if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
-		return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
-	}
+  // Verify audience matches our client ID
+  aud, err := claims.GetAudience()
+  if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
+    return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
+  }
 
-	return token, nil
+  return token, nil
 }
 
 // RegisterAuthRoutes registers the OAuth2 authentication routes
 func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
-	if config == nil {
-		return nil
-	}
+  if config == nil {
+    return nil
+  }
 
-	oidc, err := newOIDC(config)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to create OAuth2 manager")
-	}
+  oidc, err := newOIDC(config)
+  if err != nil {
+    return errors.Wrapf(err, "Failed to create OAuth2 manager")
+  }
 
-	// Register OAuth2 endpoints
-	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
-	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
-	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
-	mux.HandleFunc("/logout", oidc.logoutHandler)
+  // Register OAuth2 endpoints
+  mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
+  mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
+  mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
+  mux.HandleFunc("/logout", oidc.logoutHandler)
 
-	return nil
+  return nil
 }
 
 // NewAuthMiddleware creates a middleware that enforces OIDC authentication
 func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handler, error) {
-	if config == nil {
-		// Return a no-op middleware if OIDC is not configured
-		return func(next http.Handler) http.Handler {
-			return next
-		}, nil
-	}
+  if config == nil {
+    // Return a no-op middleware if OIDC is not configured
+    return func(next http.Handler) http.Handler {
+      return next
+    }, nil
+  }
 
-	oidc, err := newOIDC(config)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
-	}
+  oidc, err := newOIDC(config)
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
+  }
+  return newAuthMiddlewareForOIDC(oidc)
+}
 
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log := zapr.NewLogger(zap.L())
+// newAuthMiddlewareForOIDC allows our test to inject a mock OIDC
+func newAuthMiddlewareForOIDC(oidc *OIDC) (func(http.Handler) http.Handler, error) {
+  return func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+      log := zapr.NewLogger(zap.L())
 
-			// Skip authentication for login page and OAuth2 endpoints
-			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
-				next.ServeHTTP(w, r)
-				return
-			}
+      // Skip authentication for login page and OAuth2 endpoints
+      if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
+        next.ServeHTTP(w, r)
+        return
+      }
 
-			// Get the session token from the cookie
-			cookie, err := r.Cookie(sessionCookieName)
-			if err != nil {
-				// No session cookie, return 401 Unauthorized
-				log.Error(err, "No session cookie found")
-				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-				return
-			}
+      // Get the session token from the cookie
+      cookie, err := r.Cookie(sessionCookieName)
+      if err != nil {
+        // No session cookie, return 401 Unauthorized
+        log.Error(err, "No session cookie found")
+        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+        return
+      }
 
-			// Verify the token by parsing and validating the JWT
-			idToken := cookie.Value
+      // Verify the token by parsing and validating the JWT
+      idToken := cookie.Value
 
-			token, err := oidc.verifyToken(idToken)
-			if token == nil {
-				log.Error(err, "Token validation failed")
-				// Return HTTP 401 and let the client handle the redirect to the login page
-				http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
-				return
-			}
+      token, err := oidc.verifyToken(idToken)
+      if token == nil {
+        log.Error(err, "Token validation failed")
+        // Return HTTP 401 and let the client handle the redirect to the login page
+        http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
+        return
+      }
 
-			// Add the IDToken to the context
-			ctx := context.WithValue(r.Context(), IDTokenKey, token)
+      // Add the IDToken to the context
+      ctx := context.WithValue(r.Context(), IDTokenKey, token)
 
-			// Token is valid, proceed with the request
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}, nil
+      // Token is valid, proceed with the request
+      next.ServeHTTP(w, r.WithContext(ctx))
+    })
+  }, nil
 }
 
 // loginHandler handles the OAuth2 login flow
 func (o *OIDC) loginHandler(w http.ResponseWriter, r *http.Request) {
-	state, err := o.state.generateState()
-	if err != nil {
-		log := zapr.NewLogger(zap.L())
-		log.Error(err, "Failed to generate state")
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-	url := o.oauth2.AuthCodeURL(state)
-	if o.config.ForceApproval {
-		url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
-	}
-	http.Redirect(w, r, url, http.StatusFound)
+  state, err := o.state.generateState()
+  if err != nil {
+    log := zapr.NewLogger(zap.L())
+    log.Error(err, "Failed to generate state")
+    http.Error(w, "Internal server error", http.StatusInternalServerError)
+    return
+  }
+  url := o.oauth2.AuthCodeURL(state)
+  if o.config.ForceApproval {
+    url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
+  }
+  http.Redirect(w, r, url, http.StatusFound)
 }
 
 // callbackHandler handles the OAuth2 callback
 func (o *OIDC) callbackHandler(w http.ResponseWriter, r *http.Request) {
-	log := zapr.NewLogger(zap.L())
+  log := zapr.NewLogger(zap.L())
 
-	// Verify state
-	state := r.URL.Query().Get("state")
-	if !o.state.validateState(state) {
-		log.Error(nil, "Invalid state parameter")
-		redirectWithError(w, r, "invalid_state", "Invalid state parameter")
-		return
-	}
+  // Verify state
+  state := r.URL.Query().Get("state")
+  if !o.state.validateState(state) {
+    log.Error(nil, "Invalid state parameter")
+    redirectWithError(w, r, "invalid_state", "Invalid state parameter")
+    return
+  }
 
-	// Exchange code for token
-	code := r.URL.Query().Get("code")
-	token, err := o.oauth2.Exchange(r.Context(), code)
-	if err != nil {
-		log.Error(err, "Failed to exchange code for token")
-		redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
-		return
-	}
+  // Exchange code for token
+  code := r.URL.Query().Get("code")
+  token, err := o.oauth2.Exchange(r.Context(), code)
+  if err != nil {
+    log.Error(err, "Failed to exchange code for token")
+    redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
+    return
+  }
 
-	// Get the ID token from the response
-	idToken, ok := token.Extra("id_token").(string)
-	if !ok {
-		log.Error(nil, "No ID token in response")
-		redirectWithError(w, r, "no_id_token", "No ID token in response")
-		return
-	}
+  // Get the ID token from the response
+  idToken, ok := token.Extra("id_token").(string)
+  if !ok {
+    log.Error(nil, "No ID token in response")
+    redirectWithError(w, r, "no_id_token", "No ID token in response")
+    return
+  }
 
-	// Set the session cookie with the ID token
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    idToken,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+  // Set the session cookie with the ID token
+  http.SetCookie(w, &http.Cookie{
+    Name:     sessionCookieName,
+    Value:    idToken,
+    Path:     "/",
+    HttpOnly: true,
+    Secure:   true,
+    SameSite: http.SameSiteLaxMode,
+  })
 
-	// Redirect to the home page
-	http.Redirect(w, r, "/", http.StatusFound)
+  // Redirect to the home page
+  http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // redirectWithError redirects to the login page with error information
 func redirectWithError(w http.ResponseWriter, r *http.Request, errorCode, errorDescription string) {
-	// Get any existing error parameters from the request
-	existingError := r.URL.Query().Get("error")
-	existingDescription := r.URL.Query().Get("error_description")
+  // Get any existing error parameters from the request
+  existingError := r.URL.Query().Get("error")
+  existingDescription := r.URL.Query().Get("error_description")
 
-	// Use existing error parameters if they exist, otherwise use the provided ones
-	if existingError == "" {
-		existingError = errorCode
-	}
-	if existingDescription == "" {
-		existingDescription = errorDescription
-	}
+  // Use existing error parameters if they exist, otherwise use the provided ones
+  if existingError == "" {
+    existingError = errorCode
+  }
+  if existingDescription == "" {
+    existingDescription = errorDescription
+  }
 
-	// Build the redirect URL with error parameters
-	redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
-		url.QueryEscape(existingError),
-		url.QueryEscape(existingDescription))
+  // Build the redirect URL with error parameters
+  redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
+    url.QueryEscape(existingError),
+    url.QueryEscape(existingDescription))
 
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+  http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // logoutHandler handles the OAuth2 logout
 func (o *OIDC) logoutHandler(w http.ResponseWriter, r *http.Request) {
-	// Clear the session cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    "",
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-		MaxAge:   -1,
-	})
+  // Clear the session cookie
+  http.SetCookie(w, &http.Cookie{
+    Name:     sessionCookieName,
+    Value:    "",
+    Path:     "/",
+    HttpOnly: true,
+    Secure:   true,
+    SameSite: http.SameSiteLaxMode,
+    MaxAge:   -1,
+  })
 
-	// Redirect to the home page
-	http.Redirect(w, r, "/", http.StatusFound)
+  // Redirect to the home page
+  http.Redirect(w, r, "/", http.StatusFound)
 }
 
 type stateEntry struct {
-	expiresAt time.Time
+  expiresAt time.Time
 }
 
 type stateManager struct {
-	stateExpiration time.Duration
-	states          map[string]stateEntry
-	mu              sync.RWMutex
+  stateExpiration time.Duration
+  states          map[string]stateEntry
+  mu              sync.RWMutex
 }
 
 func newStateManager(stateExpiration time.Duration) *stateManager {
-	return &stateManager{
-		stateExpiration: stateExpiration,
-		states:          make(map[string]stateEntry),
-	}
+  return &stateManager{
+    stateExpiration: stateExpiration,
+    states:          make(map[string]stateEntry),
+  }
 }
 
 // generateState generates a new cryptographically secure random state
 func (sm *stateManager) generateState() (string, error) {
-	b := make([]byte, stateLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", errors.Wrap(err, "failed to generate random state")
-	}
-	state := base64.URLEncoding.EncodeToString(b)
+  b := make([]byte, stateLength)
+  if _, err := rand.Read(b); err != nil {
+    return "", errors.Wrap(err, "failed to generate random state")
+  }
+  state := base64.URLEncoding.EncodeToString(b)
 
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	sm.states[state] = stateEntry{
-		expiresAt: time.Now().Add(sm.stateExpiration),
-	}
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
+  sm.states[state] = stateEntry{
+    expiresAt: time.Now().Add(sm.stateExpiration),
+  }
 
-	return state, nil
+  return state, nil
 }
 
 // validateState checks if a state is valid and removes it if it is
 func (sm *stateManager) validateState(state string) bool {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
 
-	entry, exists := sm.states[state]
-	if !exists {
-		return false
-	}
+  entry, exists := sm.states[state]
+  if !exists {
+    return false
+  }
 
-	// Remove the state regardless of validity
-	delete(sm.states, state)
+  // Remove the state regardless of validity
+  delete(sm.states, state)
 
-	// Check if the state has expired
-	return time.Now().Before(entry.expiresAt)
+  // Check if the state has expired
+  return time.Now().Before(entry.expiresAt)
 }
 
 // cleanupExpiredStates removes expired states from the map
 func (sm *stateManager) cleanupExpiredStates() {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
 
-	now := time.Now()
-	for state, entry := range sm.states {
-		if now.After(entry.expiresAt) {
-			delete(sm.states, state)
-		}
-	}
+  now := time.Now()
+  for state, entry := range sm.states {
+    if now.After(entry.expiresAt) {
+      delete(sm.states, state)
+    }
+  }
 }
 
 // jwksKey represents a single key in the JWKS
 type jwksKey struct {
-	Kty string `json:"kty"`
-	Alg string `json:"alg"`
-	Use string `json:"use"`
-	Kid string `json:"kid"`
-	N   string `json:"n"`
-	E   string `json:"e"`
+  Kty string `json:"kty"`
+  Alg string `json:"alg"`
+  Use string `json:"use"`
+  Kid string `json:"kid"`
+  N   string `json:"n"`
+  E   string `json:"e"`
 }
 
 // jwks represents the JSON Web Key Set
 type jwks struct {
-	Keys []jwksKey `json:"keys"`
+  Keys []jwksKey `json:"keys"`
 }
 
 // openIDDiscovery is the struct for parsing the discovery document
 type openIDDiscovery struct {
-	Issuer                           string   `json:"issuer"`
-	AuthURL                          string   `json:"authorization_endpoint"`
-	TokenURL                         string   `json:"token_endpoint"`
-	JWKSURI                          string   `json:"jwks_uri"`
-	UserInfoURL                      string   `json:"userinfo_endpoint"`
-	ScopesSupported                  []string `json:"scopes_supported"`
-	ResponseTypesSupported           []string `json:"response_types_supported"`
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+  Issuer                           string   `json:"issuer"`
+  AuthURL                          string   `json:"authorization_endpoint"`
+  TokenURL                         string   `json:"token_endpoint"`
+  JWKSURI                          string   `json:"jwks_uri"`
+  UserInfoURL                      string   `json:"userinfo_endpoint"`
+  ScopesSupported                  []string `json:"scopes_supported"`
+  ResponseTypesSupported           []string `json:"response_types_supported"`
+  SubjectTypesSupported            []string `json:"subject_types_supported"`
+  IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // OIDCProvider defines the interface for OIDC providers
 type OIDCProvider interface {
-	// GetOAuth2Config returns the OAuth2 configuration
-	GetOAuth2Config() (*oauth2.Config, error)
-	// GetDiscoveryURL returns the OpenID Connect discovery URL
-	GetDiscoveryURL() string
+  // GetOAuth2Config returns the OAuth2 configuration
+  GetOAuth2Config() (*oauth2.Config, error)
+  // GetDiscoveryURL returns the OpenID Connect discovery URL
+  GetDiscoveryURL() string
 }
 
 // GoogleProvider implements OIDCProvider for Google OAuth2
 type GoogleProvider struct {
-	config *config.GoogleOIDCConfig
+  config *config.GoogleOIDCConfig
 }
 
 func NewGoogleProvider(cfg *config.GoogleOIDCConfig) *GoogleProvider {
-	return &GoogleProvider{config: cfg}
+  return &GoogleProvider{config: cfg}
 }
 
 func (p *GoogleProvider) GetOAuth2Config() (*oauth2.Config, error) {
-	bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to read client credentials file")
-	}
+  bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to read client credentials file")
+  }
 
-	config, err := google.ConfigFromJSON(bytes, "openid", "email")
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
-	}
-	return config, nil
+  config, err := google.ConfigFromJSON(bytes, "openid", "email")
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
+  }
+  return config, nil
 }
 
 func (p *GoogleProvider) GetDiscoveryURL() string {
-	return p.config.GetDiscoveryURL()
+  return p.config.GetDiscoveryURL()
 }
 
 func (p *GoogleProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-	hd, ok := claims["hd"].(string)
-	if !ok {
-		return errors.New("missing hosted domain claim")
-	}
-	if hd != "" {
-		if !slices.Contains(allowedDomains, hd) {
-			return fmt.Errorf("hosted domain %v not in allowed domains", hd)
-		}
-	} else {
-		return errors.New("missing hosted domain claim")
-	}
-	return nil
+  hd, ok := claims["hd"].(string)
+  if !ok {
+    return errors.New("missing hosted domain claim")
+  }
+  if hd != "" {
+    if !slices.Contains(allowedDomains, hd) {
+      return fmt.Errorf("hosted domain %v not in allowed domains", hd)
+    }
+  } else {
+    return errors.New("missing hosted domain claim")
+  }
+  return nil
 }
 
 // GenericProvider implements OIDCProvider for generic OIDC providers
 type GenericProvider struct {
-	config *config.GenericOIDCConfig
+  config *config.GenericOIDCConfig
 }
 
 func NewGenericProvider(cfg *config.GenericOIDCConfig) *GenericProvider {
-	return &GenericProvider{config: cfg}
+  return &GenericProvider{config: cfg}
 }
 
 func (p *GenericProvider) GetOAuth2Config() (*oauth2.Config, error) {
-	return &oauth2.Config{
-		ClientID:     p.config.ClientID,
-		ClientSecret: p.config.ClientSecret,
-		RedirectURL:  p.config.RedirectURL,
-		Scopes:       p.config.Scopes,
-	}, nil
+  return &oauth2.Config{
+    ClientID:     p.config.ClientID,
+    ClientSecret: p.config.ClientSecret,
+    RedirectURL:  p.config.RedirectURL,
+    Scopes:       p.config.Scopes,
+  }, nil
 }
 
 func (p *GenericProvider) GetDiscoveryURL() string {
-	return p.config.GetDiscoveryURL()
+  return p.config.GetDiscoveryURL()
 }
 
 func (p *GenericProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-	email, ok := claims["email"].(string)
-	if !ok {
-		return errors.New("missing email claim")
-	}
+  email, ok := claims["email"].(string)
+  if !ok {
+    return errors.New("missing email claim")
+  }
 
-	if email == "" {
-		return errors.New("empty email claim")
-	}
+  if email == "" {
+    return errors.New("empty email claim")
+  }
 
-	parts := strings.Split(email, "@")
-	if len(parts) != 2 {
-		return errors.New("invalid email format")
-	}
+  parts := strings.Split(email, "@")
+  if len(parts) != 2 {
+    return errors.New("invalid email format")
+  }
 
-	emailDomain := parts[1]
-	if !slices.Contains(allowedDomains, emailDomain) {
-		return fmt.Errorf("email domain not in allowed domains: %s", email)
-	}
+  emailDomain := parts[1]
+  if !slices.Contains(allowedDomains, emailDomain) {
+    return fmt.Errorf("email domain not in allowed domains: %s", email)
+  }
 
-	return nil
+  return nil
 }
 
 // AuthMux wraps http.ServeMux to add protected route handling
 type AuthMux struct {
-	mux            *http.ServeMux
-	authMiddleware func(http.Handler) http.Handler
-	serverConfig   *config.AssistantServerConfig
+  mux            *http.ServeMux
+  authMiddleware func(http.Handler) http.Handler
+  serverConfig   *config.AssistantServerConfig
 }
 
 // NewAuthMux creates a new AuthMux
 func NewAuthMux(serverConfig *config.AssistantServerConfig) (*AuthMux, error) {
-	mux := http.NewServeMux()
+  mux := http.NewServeMux()
 
-	// Create auth middleware if OIDC is configured
-	var authMiddleware func(http.Handler) http.Handler
-	if serverConfig != nil && serverConfig.OIDC != nil {
-		middleware, err := NewAuthMiddleware(serverConfig.OIDC)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to create auth middleware")
-		}
-		authMiddleware = middleware
-	} else {
-		// No-op middleware if OIDC is not configured
-		authMiddleware = func(next http.Handler) http.Handler {
-			return next
-		}
-	}
+  // Create auth middleware if OIDC is configured
+  var authMiddleware func(http.Handler) http.Handler
+  if serverConfig != nil && serverConfig.OIDC != nil {
+    middleware, err := NewAuthMiddleware(serverConfig.OIDC)
+    if err != nil {
+      return nil, errors.Wrapf(err, "Failed to create auth middleware")
+    }
+    authMiddleware = middleware
+  } else {
+    // No-op middleware if OIDC is not configured
+    authMiddleware = func(next http.Handler) http.Handler {
+      return next
+    }
+  }
 
-	return &AuthMux{
-		mux:            mux,
-		authMiddleware: authMiddleware,
-		serverConfig:   serverConfig,
-	}, nil
+  return &AuthMux{
+    mux:            mux,
+    authMiddleware: authMiddleware,
+    serverConfig:   serverConfig,
+  }, nil
 }
 
 // Handle registers a handler for the given pattern
 func (p *AuthMux) Handle(pattern string, handler http.Handler) {
-	p.mux.Handle(pattern, handler)
+  p.mux.Handle(pattern, handler)
 }
 
 // HandleFunc registers a handler function for the given pattern
 func (p *AuthMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	p.mux.HandleFunc(pattern, handler)
+  p.mux.HandleFunc(pattern, handler)
 }
 
 // HandleProtected registers a protected handler for the given pattern
 func (p *AuthMux) HandleProtected(pattern string, handler http.Handler, checker iam.Checker, role string) {
-	// Apply CORS if origins are configured
-	if len(p.serverConfig.CorsOrigins) > 0 {
-		c := cors.New(cors.Options{
-			AllowedOrigins: p.serverConfig.CorsOrigins,
-			AllowedMethods: connectcors.AllowedMethods(),
-			AllowedHeaders: connectcors.AllowedHeaders(),
-			ExposedHeaders: connectcors.ExposedHeaders(),
-			MaxAge:         7200, // 2 hours in seconds
-		})
-		handler = c.Handler(handler)
-	}
+  // Apply CORS if origins are configured
+  if len(p.serverConfig.CorsOrigins) > 0 {
+    c := cors.New(cors.Options{
+      AllowedOrigins: p.serverConfig.CorsOrigins,
+      AllowedMethods: connectcors.AllowedMethods(),
+      AllowedHeaders: connectcors.AllowedHeaders(),
+      ExposedHeaders: connectcors.ExposedHeaders(),
+      MaxAge:         7200, // 2 hours in seconds
+    })
+    handler = c.Handler(handler)
+  }
 
-	// We need to create a new Auth middleware that will apply the IAM checks specific to this handler
-	iamChecker := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+  // We need to create a new Auth middleware that will apply the IAM checks specific to this handler
+  iamChecker := func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			log := logs.FromContext(r.Context())
-			idToken := getIDToken(r.Context())
-			if idToken == nil {
-				log.Info("Unauthorized: No session")
-				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-				return
-			}
+      log := logs.FromContext(r.Context())
+      idToken := getIDToken(r.Context())
+      if idToken == nil {
+        log.Info("Unauthorized: No session")
+        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+        return
+      }
 
-			claims, ok := idToken.Claims.(jwt.MapClaims)
-			if !ok {
-				log.Info("Unauthorized invalid claims")
-				http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
-				return
-			}
+      claims, ok := idToken.Claims.(jwt.MapClaims)
+      if !ok {
+        log.Info("Unauthorized invalid claims")
+        http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
+        return
+      }
 
-			email, ok := claims["email"].(string)
-			if !ok {
-				log.Info("Unauthorized: Missing email claim")
-				http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
-				return
-			}
+      email, ok := claims["email"].(string)
+      if !ok {
+        log.Info("Unauthorized: Missing email claim")
+        http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
+        return
+      }
 
-			if !checker.Check(email, role) {
-				log.Info("Unauthorized", "user", email, "role", role)
-				http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
-				return
-			}
+      if !checker.Check(email, role) {
+        log.Info("Unauthorized", "user", email, "role", role)
+        http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
+        return
+      }
 
-			// Get the IDToken from the context
-			next.ServeHTTP(w, r)
-		})
-	}
+      // Get the IDToken from the context
+      next.ServeHTTP(w, r)
+    })
+  }
 
-	// Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
-	p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
+  // Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
+  p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
 }
 
 // HandleProtectedFunc registers a protected handler function for the given pattern
 func (p *AuthMux) HandleProtectedFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
+  p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
 }
 
 // ServeHTTP implements http.Handler
 func (p *AuthMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	p.mux.ServeHTTP(w, r)
+  p.mux.ServeHTTP(w, r)
 }
 
 // getIDToken retrieves the ID token from the context if there is one or nil
 func getIDToken(ctx context.Context) *jwt.Token {
-	idToken := ctx.Value(IDTokenKey)
-	if idToken == nil {
-		return nil
-	}
-	token, ok := idToken.(*jwt.Token)
-	if !ok {
-		log := zapr.NewLogger(zap.L())
-		log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
-		return nil
-	}
-	return token
+  idToken := ctx.Value(IDTokenKey)
+  if idToken == nil {
+    return nil
+  }
+  token, ok := idToken.(*jwt.Token)
+  if !ok {
+    log := zapr.NewLogger(zap.L())
+    log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
+    return nil
+  }
+  return token
 }

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -7,8 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/jlewi/cloud-assistant/app/pkg/iam"
-	"github.com/jlewi/cloud-assistant/app/pkg/logs"
 	"math/big"
 	"net/http"
 	"net/url"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jlewi/cloud-assistant/app/pkg/iam"
+	"github.com/jlewi/cloud-assistant/app/pkg/logs"
 
 	connectcors "connectrpc.com/cors"
 	"github.com/go-logr/zapr"

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -1,133 +1,133 @@
 package server
 
 import (
-  "context"
-  "crypto/rand"
-  "crypto/rsa"
-  "encoding/base64"
-  "encoding/json"
-  "fmt"
-  "math/big"
-  "net/http"
-  "net/url"
-  "os"
-  "slices"
-  "strings"
-  "sync"
-  "time"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
 
-  "github.com/jlewi/cloud-assistant/app/pkg/iam"
-  "github.com/jlewi/cloud-assistant/app/pkg/logs"
+	"github.com/jlewi/cloud-assistant/app/pkg/iam"
+	"github.com/jlewi/cloud-assistant/app/pkg/logs"
 
-  connectcors "connectrpc.com/cors"
-  "github.com/go-logr/zapr"
-  "github.com/golang-jwt/jwt/v5"
-  "github.com/jlewi/cloud-assistant/app/pkg/config"
-  "github.com/pkg/errors"
-  "github.com/rs/cors"
-  "go.uber.org/zap"
-  "golang.org/x/oauth2"
-  "golang.org/x/oauth2/google"
+	connectcors "connectrpc.com/cors"
+	"github.com/go-logr/zapr"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/rs/cors"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 const (
-  oidcPathPrefix    = "/oidc"
-  sessionCookieName = "cassie-session"
-  stateLength       = 32
-  IDTokenKey        = "idToken"
+	oidcPathPrefix    = "/oidc"
+	sessionCookieName = "cassie-session"
+	stateLength       = 32
+	IDTokenKey        = "idToken"
 )
 
 // OIDC handles OAuth2 authentication setup and management
 type OIDC struct {
-  config     *config.OIDCConfig
-  oauth2     *oauth2.Config
-  publicKeys map[string]*rsa.PublicKey
-  discovery  *openIDDiscovery
-  state      *stateManager
-  provider   OIDCProvider
+	config     *config.OIDCConfig
+	oauth2     *oauth2.Config
+	publicKeys map[string]*rsa.PublicKey
+	discovery  *openIDDiscovery
+	state      *stateManager
+	provider   OIDCProvider
 }
 
 // newOIDC creates a new OIDC
 func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
-  if cfg == nil {
-    return nil, nil
-  }
+	if cfg == nil {
+		return nil, nil
+	}
 
-  // Check that only one provider is configured
-  if cfg.Google != nil && cfg.Generic != nil {
-    return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
-  }
+	// Check that only one provider is configured
+	if cfg.Google != nil && cfg.Generic != nil {
+		return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
+	}
 
-  if cfg.Google == nil && cfg.Generic == nil {
-    return nil, nil
-  }
+	if cfg.Google == nil && cfg.Generic == nil {
+		return nil, nil
+	}
 
-  var provider OIDCProvider
-  if cfg.Google != nil {
-    provider = NewGoogleProvider(cfg.Google)
-  } else {
-    provider = NewGenericProvider(cfg.Generic)
-  }
+	var provider OIDCProvider
+	if cfg.Google != nil {
+		provider = NewGoogleProvider(cfg.Google)
+	} else {
+		provider = NewGenericProvider(cfg.Generic)
+	}
 
-  oauth2Config, err := provider.GetOAuth2Config()
-  if err != nil {
-    return nil, err
-  }
+	oauth2Config, err := provider.GetOAuth2Config()
+	if err != nil {
+		return nil, err
+	}
 
-  discoveryURL := provider.GetDiscoveryURL()
+	discoveryURL := provider.GetDiscoveryURL()
 
-  // Fetch the OpenID configuration
-  resp, err := http.Get(discoveryURL)
-  if err != nil {
-    return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
-  }
-  defer func() {
-    if err := resp.Body.Close(); err != nil {
-      zap.L().Error("failed to close response body", zap.Error(err))
-    }
-  }()
+	// Fetch the OpenID configuration
+	resp, err := http.Get(discoveryURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
-  var discovery openIDDiscovery
-  if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
-    return nil, errors.Wrap(err, "failed to decode OpenID configuration")
-  }
+	var discovery openIDDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+		return nil, errors.Wrap(err, "failed to decode OpenID configuration")
+	}
 
-  // Update endpoints from discovery document
-  oauth2Config.Endpoint = oauth2.Endpoint{
-    AuthURL:  discovery.AuthURL,
-    TokenURL: discovery.TokenURL,
-  }
+	// Update endpoints from discovery document
+	oauth2Config.Endpoint = oauth2.Endpoint{
+		AuthURL:  discovery.AuthURL,
+		TokenURL: discovery.TokenURL,
+	}
 
-  // If the generic provider is configured with an issuer, use it
-  if cfg.Generic != nil && cfg.Generic.Issuer != "" {
-    discovery.Issuer = cfg.Generic.Issuer
-  }
+	// If the generic provider is configured with an issuer, use it
+	if cfg.Generic != nil && cfg.Generic.Issuer != "" {
+		discovery.Issuer = cfg.Generic.Issuer
+	}
 
-  // Initialize OIDC
-  oidc := &OIDC{
-    config:     cfg,
-    oauth2:     oauth2Config,
-    publicKeys: make(map[string]*rsa.PublicKey),
-    discovery:  &discovery,
-    state:      newStateManager(10 * time.Minute),
-    provider:   provider,
-  }
+	// Initialize OIDC
+	oidc := &OIDC{
+		config:     cfg,
+		oauth2:     oauth2Config,
+		publicKeys: make(map[string]*rsa.PublicKey),
+		discovery:  &discovery,
+		state:      newStateManager(10 * time.Minute),
+		provider:   provider,
+	}
 
-  // Download JWKS for signature verification
-  if err := oidc.downloadJWKS(); err != nil {
-    return nil, errors.Wrapf(err, "Failed to download JWKS")
-  }
+	// Download JWKS for signature verification
+	if err := oidc.downloadJWKS(); err != nil {
+		return nil, errors.Wrapf(err, "Failed to download JWKS")
+	}
 
-  // Start a goroutine to clean up expired states
-  go func() {
-    ticker := time.NewTicker(oidc.state.stateExpiration / 2)
-    defer ticker.Stop()
-    for range ticker.C {
-      oidc.state.cleanupExpiredStates()
-    }
-  }()
+	// Start a goroutine to clean up expired states
+	go func() {
+		ticker := time.NewTicker(oidc.state.stateExpiration / 2)
+		defer ticker.Stop()
+		for range ticker.C {
+			oidc.state.cleanupExpiredStates()
+		}
+	}()
 
-  return oidc, nil
+	return oidc, nil
 }
 
 // downloadJWKS downloads the JSON Web Key Set (JWKS) from Google's OAuth2 provider.
@@ -136,601 +136,601 @@ func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
 // This allows the application to verify tokens offline without contacting Google's servers
 // for each verification request.
 func (o *OIDC) downloadJWKS() error {
-  // Fetch the JWKS from the URI specified in the discovery document
-  resp, err := http.Get(o.discovery.JWKSURI)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
-  }
-  defer func() {
-    if err := resp.Body.Close(); err != nil {
-      zap.L().Error("failed to close response body", zap.Error(err))
-    }
-  }()
+	// Fetch the JWKS from the URI specified in the discovery document
+	resp, err := http.Get(o.discovery.JWKSURI)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
-  // Parse the JWKS into our structured format
-  var jwks jwks
-  if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-    return errors.Wrapf(err, "Failed to parse JWKS response")
-  }
+	// Parse the JWKS into our structured format
+	var jwks jwks
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return errors.Wrapf(err, "Failed to parse JWKS response")
+	}
 
-  // Convert each key to RSA public key and store in the map
-  for _, key := range jwks.Keys {
-    // Convert the modulus and exponent from base64url to *rsa.PublicKey
-    n, err := base64.RawURLEncoding.DecodeString(key.N)
-    if err != nil {
-      return errors.Wrap(err, "failed to decode modulus")
-    }
+	// Convert each key to RSA public key and store in the map
+	for _, key := range jwks.Keys {
+		// Convert the modulus and exponent from base64url to *rsa.PublicKey
+		n, err := base64.RawURLEncoding.DecodeString(key.N)
+		if err != nil {
+			return errors.Wrap(err, "failed to decode modulus")
+		}
 
-    e, err := base64.RawURLEncoding.DecodeString(key.E)
-    if err != nil {
-      return errors.Wrap(err, "failed to decode exponent")
-    }
+		e, err := base64.RawURLEncoding.DecodeString(key.E)
+		if err != nil {
+			return errors.Wrap(err, "failed to decode exponent")
+		}
 
-    // Convert the modulus to a big integer
-    modulus := new(big.Int).SetBytes(n)
+		// Convert the modulus to a big integer
+		modulus := new(big.Int).SetBytes(n)
 
-    // Convert the exponent to an integer
-    var exponent int
-    if len(e) < 4 {
-      for i := range e {
-        exponent = exponent<<8 + int(e[i])
-      }
-    } else {
-      return errors.New("exponent too large")
-    }
+		// Convert the exponent to an integer
+		var exponent int
+		if len(e) < 4 {
+			for i := range e {
+				exponent = exponent<<8 + int(e[i])
+			}
+		} else {
+			return errors.New("exponent too large")
+		}
 
-    // Create the RSA public key
-    publicKey := &rsa.PublicKey{
-      N: modulus,
-      E: exponent,
-    }
+		// Create the RSA public key
+		publicKey := &rsa.PublicKey{
+			N: modulus,
+			E: exponent,
+		}
 
-    // Store the public key in the map using the kid as the key
-    o.publicKeys[key.Kid] = publicKey
-  }
+		// Store the public key in the map using the kid as the key
+		o.publicKeys[key.Kid] = publicKey
+	}
 
-  return nil
+	return nil
 }
 
 // verifyToken verifies the JWT token and returns whether it's valid and any error encountered
 // result is nil if its an invalid token and non-nil if its valid
 func (o *OIDC) verifyToken(idToken string) (*jwt.Token, error) {
-  // Verify the token signature using JWKS
-  token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
-    // Verify the signing method is what we expect
-    if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-      return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-    }
+	// Verify the token signature using JWKS
+	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+		// Verify the signing method is what we expect
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
 
-    // Get the key ID from the token header
-    kid, ok := token.Header["kid"].(string)
-    if !ok {
-      return nil, errors.New("kid header not found in token")
-    }
+		// Get the key ID from the token header
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("kid header not found in token")
+		}
 
-    // Get the public key from our map
-    publicKey, ok := o.publicKeys[kid]
-    if !ok {
-      return nil, errors.New("unable to find appropriate key")
-    }
+		// Get the public key from our map
+		publicKey, ok := o.publicKeys[kid]
+		if !ok {
+			return nil, errors.New("unable to find appropriate key")
+		}
 
-    return publicKey, nil
-  })
+		return publicKey, nil
+	})
 
-  if err != nil || !token.Valid {
-    return nil, fmt.Errorf("invalid token signature: %v", err)
-  }
+	if err != nil || !token.Valid {
+		return nil, fmt.Errorf("invalid token signature: %v", err)
+	}
 
-  // Get the claims from the token
-  claims, ok := token.Claims.(jwt.MapClaims)
-  if !ok {
-    return nil, errors.New("failed to get claims from token")
-  }
+	// Get the claims from the token
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("failed to get claims from token")
+	}
 
-  // Verify expiration
-  exp, err := claims.GetExpirationTime()
-  if err != nil {
-    return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
-  }
-  if time.Now().After(exp.Time) {
-    return nil, errors.New("token expired")
-  }
+	// Verify expiration
+	exp, err := claims.GetExpirationTime()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
+	}
+	if time.Now().After(exp.Time) {
+		return nil, errors.New("token expired")
+	}
 
-  // Verify issuer
-  iss, err := claims.GetIssuer()
-  if err != nil || iss != o.discovery.Issuer {
-    return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
-  }
+	// Verify issuer
+	iss, err := claims.GetIssuer()
+	if err != nil || iss != o.discovery.Issuer {
+		return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
+	}
 
-  // Verify audience matches our client ID
-  aud, err := claims.GetAudience()
-  if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
-    return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
-  }
+	// Verify audience matches our client ID
+	aud, err := claims.GetAudience()
+	if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
+		return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
+	}
 
-  return token, nil
+	return token, nil
 }
 
 // RegisterAuthRoutes registers the OAuth2 authentication routes
 func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
-  if config == nil {
-    return nil
-  }
+	if config == nil {
+		return nil
+	}
 
-  oidc, err := newOIDC(config)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to create OAuth2 manager")
-  }
+	oidc, err := newOIDC(config)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create OAuth2 manager")
+	}
 
-  // Register OAuth2 endpoints
-  mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
-  mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
-  mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
-  mux.HandleFunc("/logout", oidc.logoutHandler)
+	// Register OAuth2 endpoints
+	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
+	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
+	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
+	mux.HandleFunc("/logout", oidc.logoutHandler)
 
-  return nil
+	return nil
 }
 
 // NewAuthMiddleware creates a middleware that enforces OIDC authentication
 func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handler, error) {
-  if config == nil {
-    // Return a no-op middleware if OIDC is not configured
-    return func(next http.Handler) http.Handler {
-      return next
-    }, nil
-  }
+	if config == nil {
+		// Return a no-op middleware if OIDC is not configured
+		return func(next http.Handler) http.Handler {
+			return next
+		}, nil
+	}
 
-  oidc, err := newOIDC(config)
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
-  }
-  return newAuthMiddlewareForOIDC(oidc)
+	oidc, err := newOIDC(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
+	}
+	return newAuthMiddlewareForOIDC(oidc)
 }
 
 // newAuthMiddlewareForOIDC allows our test to inject a mock OIDC
 func newAuthMiddlewareForOIDC(oidc *OIDC) (func(http.Handler) http.Handler, error) {
-  return func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-      log := zapr.NewLogger(zap.L())
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log := zapr.NewLogger(zap.L())
 
-      // Skip authentication for login page and OAuth2 endpoints
-      if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
-        next.ServeHTTP(w, r)
-        return
-      }
+			// Skip authentication for login page and OAuth2 endpoints
+			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
+				next.ServeHTTP(w, r)
+				return
+			}
 
-      // Get the session token from the cookie
-      cookie, err := r.Cookie(sessionCookieName)
-      if err != nil {
-        // No session cookie, return 401 Unauthorized
-        log.Error(err, "No session cookie found")
-        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-        return
-      }
+			// Get the session token from the cookie
+			cookie, err := r.Cookie(sessionCookieName)
+			if err != nil {
+				// No session cookie, return 401 Unauthorized
+				log.Error(err, "No session cookie found")
+				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+				return
+			}
 
-      // Verify the token by parsing and validating the JWT
-      idToken := cookie.Value
+			// Verify the token by parsing and validating the JWT
+			idToken := cookie.Value
 
-      token, err := oidc.verifyToken(idToken)
-      if token == nil {
-        log.Error(err, "Token validation failed")
-        // Return HTTP 401 and let the client handle the redirect to the login page
-        http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
-        return
-      }
+			token, err := oidc.verifyToken(idToken)
+			if token == nil {
+				log.Error(err, "Token validation failed")
+				// Return HTTP 401 and let the client handle the redirect to the login page
+				http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
+				return
+			}
 
-      // Add the IDToken to the context
-      ctx := context.WithValue(r.Context(), IDTokenKey, token)
+			// Add the IDToken to the context
+			ctx := context.WithValue(r.Context(), IDTokenKey, token)
 
-      // Token is valid, proceed with the request
-      next.ServeHTTP(w, r.WithContext(ctx))
-    })
-  }, nil
+			// Token is valid, proceed with the request
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}, nil
 }
 
 // loginHandler handles the OAuth2 login flow
 func (o *OIDC) loginHandler(w http.ResponseWriter, r *http.Request) {
-  state, err := o.state.generateState()
-  if err != nil {
-    log := zapr.NewLogger(zap.L())
-    log.Error(err, "Failed to generate state")
-    http.Error(w, "Internal server error", http.StatusInternalServerError)
-    return
-  }
-  url := o.oauth2.AuthCodeURL(state)
-  if o.config.ForceApproval {
-    url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
-  }
-  http.Redirect(w, r, url, http.StatusFound)
+	state, err := o.state.generateState()
+	if err != nil {
+		log := zapr.NewLogger(zap.L())
+		log.Error(err, "Failed to generate state")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	url := o.oauth2.AuthCodeURL(state)
+	if o.config.ForceApproval {
+		url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
+	}
+	http.Redirect(w, r, url, http.StatusFound)
 }
 
 // callbackHandler handles the OAuth2 callback
 func (o *OIDC) callbackHandler(w http.ResponseWriter, r *http.Request) {
-  log := zapr.NewLogger(zap.L())
+	log := zapr.NewLogger(zap.L())
 
-  // Verify state
-  state := r.URL.Query().Get("state")
-  if !o.state.validateState(state) {
-    log.Error(nil, "Invalid state parameter")
-    redirectWithError(w, r, "invalid_state", "Invalid state parameter")
-    return
-  }
+	// Verify state
+	state := r.URL.Query().Get("state")
+	if !o.state.validateState(state) {
+		log.Error(nil, "Invalid state parameter")
+		redirectWithError(w, r, "invalid_state", "Invalid state parameter")
+		return
+	}
 
-  // Exchange code for token
-  code := r.URL.Query().Get("code")
-  token, err := o.oauth2.Exchange(r.Context(), code)
-  if err != nil {
-    log.Error(err, "Failed to exchange code for token")
-    redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
-    return
-  }
+	// Exchange code for token
+	code := r.URL.Query().Get("code")
+	token, err := o.oauth2.Exchange(r.Context(), code)
+	if err != nil {
+		log.Error(err, "Failed to exchange code for token")
+		redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
+		return
+	}
 
-  // Get the ID token from the response
-  idToken, ok := token.Extra("id_token").(string)
-  if !ok {
-    log.Error(nil, "No ID token in response")
-    redirectWithError(w, r, "no_id_token", "No ID token in response")
-    return
-  }
+	// Get the ID token from the response
+	idToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		log.Error(nil, "No ID token in response")
+		redirectWithError(w, r, "no_id_token", "No ID token in response")
+		return
+	}
 
-  // Set the session cookie with the ID token
-  http.SetCookie(w, &http.Cookie{
-    Name:     sessionCookieName,
-    Value:    idToken,
-    Path:     "/",
-    HttpOnly: true,
-    Secure:   true,
-    SameSite: http.SameSiteLaxMode,
-  })
+	// Set the session cookie with the ID token
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    idToken,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 
-  // Redirect to the home page
-  http.Redirect(w, r, "/", http.StatusFound)
+	// Redirect to the home page
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // redirectWithError redirects to the login page with error information
 func redirectWithError(w http.ResponseWriter, r *http.Request, errorCode, errorDescription string) {
-  // Get any existing error parameters from the request
-  existingError := r.URL.Query().Get("error")
-  existingDescription := r.URL.Query().Get("error_description")
+	// Get any existing error parameters from the request
+	existingError := r.URL.Query().Get("error")
+	existingDescription := r.URL.Query().Get("error_description")
 
-  // Use existing error parameters if they exist, otherwise use the provided ones
-  if existingError == "" {
-    existingError = errorCode
-  }
-  if existingDescription == "" {
-    existingDescription = errorDescription
-  }
+	// Use existing error parameters if they exist, otherwise use the provided ones
+	if existingError == "" {
+		existingError = errorCode
+	}
+	if existingDescription == "" {
+		existingDescription = errorDescription
+	}
 
-  // Build the redirect URL with error parameters
-  redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
-    url.QueryEscape(existingError),
-    url.QueryEscape(existingDescription))
+	// Build the redirect URL with error parameters
+	redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
+		url.QueryEscape(existingError),
+		url.QueryEscape(existingDescription))
 
-  http.Redirect(w, r, redirectURL, http.StatusFound)
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // logoutHandler handles the OAuth2 logout
 func (o *OIDC) logoutHandler(w http.ResponseWriter, r *http.Request) {
-  // Clear the session cookie
-  http.SetCookie(w, &http.Cookie{
-    Name:     sessionCookieName,
-    Value:    "",
-    Path:     "/",
-    HttpOnly: true,
-    Secure:   true,
-    SameSite: http.SameSiteLaxMode,
-    MaxAge:   -1,
-  })
+	// Clear the session cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
 
-  // Redirect to the home page
-  http.Redirect(w, r, "/", http.StatusFound)
+	// Redirect to the home page
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 type stateEntry struct {
-  expiresAt time.Time
+	expiresAt time.Time
 }
 
 type stateManager struct {
-  stateExpiration time.Duration
-  states          map[string]stateEntry
-  mu              sync.RWMutex
+	stateExpiration time.Duration
+	states          map[string]stateEntry
+	mu              sync.RWMutex
 }
 
 func newStateManager(stateExpiration time.Duration) *stateManager {
-  return &stateManager{
-    stateExpiration: stateExpiration,
-    states:          make(map[string]stateEntry),
-  }
+	return &stateManager{
+		stateExpiration: stateExpiration,
+		states:          make(map[string]stateEntry),
+	}
 }
 
 // generateState generates a new cryptographically secure random state
 func (sm *stateManager) generateState() (string, error) {
-  b := make([]byte, stateLength)
-  if _, err := rand.Read(b); err != nil {
-    return "", errors.Wrap(err, "failed to generate random state")
-  }
-  state := base64.URLEncoding.EncodeToString(b)
+	b := make([]byte, stateLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", errors.Wrap(err, "failed to generate random state")
+	}
+	state := base64.URLEncoding.EncodeToString(b)
 
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
-  sm.states[state] = stateEntry{
-    expiresAt: time.Now().Add(sm.stateExpiration),
-  }
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.states[state] = stateEntry{
+		expiresAt: time.Now().Add(sm.stateExpiration),
+	}
 
-  return state, nil
+	return state, nil
 }
 
 // validateState checks if a state is valid and removes it if it is
 func (sm *stateManager) validateState(state string) bool {
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 
-  entry, exists := sm.states[state]
-  if !exists {
-    return false
-  }
+	entry, exists := sm.states[state]
+	if !exists {
+		return false
+	}
 
-  // Remove the state regardless of validity
-  delete(sm.states, state)
+	// Remove the state regardless of validity
+	delete(sm.states, state)
 
-  // Check if the state has expired
-  return time.Now().Before(entry.expiresAt)
+	// Check if the state has expired
+	return time.Now().Before(entry.expiresAt)
 }
 
 // cleanupExpiredStates removes expired states from the map
 func (sm *stateManager) cleanupExpiredStates() {
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 
-  now := time.Now()
-  for state, entry := range sm.states {
-    if now.After(entry.expiresAt) {
-      delete(sm.states, state)
-    }
-  }
+	now := time.Now()
+	for state, entry := range sm.states {
+		if now.After(entry.expiresAt) {
+			delete(sm.states, state)
+		}
+	}
 }
 
 // jwksKey represents a single key in the JWKS
 type jwksKey struct {
-  Kty string `json:"kty"`
-  Alg string `json:"alg"`
-  Use string `json:"use"`
-  Kid string `json:"kid"`
-  N   string `json:"n"`
-  E   string `json:"e"`
+	Kty string `json:"kty"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
 }
 
 // jwks represents the JSON Web Key Set
 type jwks struct {
-  Keys []jwksKey `json:"keys"`
+	Keys []jwksKey `json:"keys"`
 }
 
 // openIDDiscovery is the struct for parsing the discovery document
 type openIDDiscovery struct {
-  Issuer                           string   `json:"issuer"`
-  AuthURL                          string   `json:"authorization_endpoint"`
-  TokenURL                         string   `json:"token_endpoint"`
-  JWKSURI                          string   `json:"jwks_uri"`
-  UserInfoURL                      string   `json:"userinfo_endpoint"`
-  ScopesSupported                  []string `json:"scopes_supported"`
-  ResponseTypesSupported           []string `json:"response_types_supported"`
-  SubjectTypesSupported            []string `json:"subject_types_supported"`
-  IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	Issuer                           string   `json:"issuer"`
+	AuthURL                          string   `json:"authorization_endpoint"`
+	TokenURL                         string   `json:"token_endpoint"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	UserInfoURL                      string   `json:"userinfo_endpoint"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // OIDCProvider defines the interface for OIDC providers
 type OIDCProvider interface {
-  // GetOAuth2Config returns the OAuth2 configuration
-  GetOAuth2Config() (*oauth2.Config, error)
-  // GetDiscoveryURL returns the OpenID Connect discovery URL
-  GetDiscoveryURL() string
+	// GetOAuth2Config returns the OAuth2 configuration
+	GetOAuth2Config() (*oauth2.Config, error)
+	// GetDiscoveryURL returns the OpenID Connect discovery URL
+	GetDiscoveryURL() string
 }
 
 // GoogleProvider implements OIDCProvider for Google OAuth2
 type GoogleProvider struct {
-  config *config.GoogleOIDCConfig
+	config *config.GoogleOIDCConfig
 }
 
 func NewGoogleProvider(cfg *config.GoogleOIDCConfig) *GoogleProvider {
-  return &GoogleProvider{config: cfg}
+	return &GoogleProvider{config: cfg}
 }
 
 func (p *GoogleProvider) GetOAuth2Config() (*oauth2.Config, error) {
-  bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to read client credentials file")
-  }
+	bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read client credentials file")
+	}
 
-  config, err := google.ConfigFromJSON(bytes, "openid", "email")
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
-  }
-  return config, nil
+	config, err := google.ConfigFromJSON(bytes, "openid", "email")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
+	}
+	return config, nil
 }
 
 func (p *GoogleProvider) GetDiscoveryURL() string {
-  return p.config.GetDiscoveryURL()
+	return p.config.GetDiscoveryURL()
 }
 
 func (p *GoogleProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-  hd, ok := claims["hd"].(string)
-  if !ok {
-    return errors.New("missing hosted domain claim")
-  }
-  if hd != "" {
-    if !slices.Contains(allowedDomains, hd) {
-      return fmt.Errorf("hosted domain %v not in allowed domains", hd)
-    }
-  } else {
-    return errors.New("missing hosted domain claim")
-  }
-  return nil
+	hd, ok := claims["hd"].(string)
+	if !ok {
+		return errors.New("missing hosted domain claim")
+	}
+	if hd != "" {
+		if !slices.Contains(allowedDomains, hd) {
+			return fmt.Errorf("hosted domain %v not in allowed domains", hd)
+		}
+	} else {
+		return errors.New("missing hosted domain claim")
+	}
+	return nil
 }
 
 // GenericProvider implements OIDCProvider for generic OIDC providers
 type GenericProvider struct {
-  config *config.GenericOIDCConfig
+	config *config.GenericOIDCConfig
 }
 
 func NewGenericProvider(cfg *config.GenericOIDCConfig) *GenericProvider {
-  return &GenericProvider{config: cfg}
+	return &GenericProvider{config: cfg}
 }
 
 func (p *GenericProvider) GetOAuth2Config() (*oauth2.Config, error) {
-  return &oauth2.Config{
-    ClientID:     p.config.ClientID,
-    ClientSecret: p.config.ClientSecret,
-    RedirectURL:  p.config.RedirectURL,
-    Scopes:       p.config.Scopes,
-  }, nil
+	return &oauth2.Config{
+		ClientID:     p.config.ClientID,
+		ClientSecret: p.config.ClientSecret,
+		RedirectURL:  p.config.RedirectURL,
+		Scopes:       p.config.Scopes,
+	}, nil
 }
 
 func (p *GenericProvider) GetDiscoveryURL() string {
-  return p.config.GetDiscoveryURL()
+	return p.config.GetDiscoveryURL()
 }
 
 func (p *GenericProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-  email, ok := claims["email"].(string)
-  if !ok {
-    return errors.New("missing email claim")
-  }
+	email, ok := claims["email"].(string)
+	if !ok {
+		return errors.New("missing email claim")
+	}
 
-  if email == "" {
-    return errors.New("empty email claim")
-  }
+	if email == "" {
+		return errors.New("empty email claim")
+	}
 
-  parts := strings.Split(email, "@")
-  if len(parts) != 2 {
-    return errors.New("invalid email format")
-  }
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return errors.New("invalid email format")
+	}
 
-  emailDomain := parts[1]
-  if !slices.Contains(allowedDomains, emailDomain) {
-    return fmt.Errorf("email domain not in allowed domains: %s", email)
-  }
+	emailDomain := parts[1]
+	if !slices.Contains(allowedDomains, emailDomain) {
+		return fmt.Errorf("email domain not in allowed domains: %s", email)
+	}
 
-  return nil
+	return nil
 }
 
 // AuthMux wraps http.ServeMux to add protected route handling
 type AuthMux struct {
-  mux            *http.ServeMux
-  authMiddleware func(http.Handler) http.Handler
-  serverConfig   *config.AssistantServerConfig
+	mux            *http.ServeMux
+	authMiddleware func(http.Handler) http.Handler
+	serverConfig   *config.AssistantServerConfig
 }
 
 // NewAuthMux creates a new AuthMux
 func NewAuthMux(serverConfig *config.AssistantServerConfig) (*AuthMux, error) {
-  mux := http.NewServeMux()
+	mux := http.NewServeMux()
 
-  // Create auth middleware if OIDC is configured
-  var authMiddleware func(http.Handler) http.Handler
-  if serverConfig != nil && serverConfig.OIDC != nil {
-    middleware, err := NewAuthMiddleware(serverConfig.OIDC)
-    if err != nil {
-      return nil, errors.Wrapf(err, "Failed to create auth middleware")
-    }
-    authMiddleware = middleware
-  } else {
-    // No-op middleware if OIDC is not configured
-    authMiddleware = func(next http.Handler) http.Handler {
-      return next
-    }
-  }
+	// Create auth middleware if OIDC is configured
+	var authMiddleware func(http.Handler) http.Handler
+	if serverConfig != nil && serverConfig.OIDC != nil {
+		middleware, err := NewAuthMiddleware(serverConfig.OIDC)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create auth middleware")
+		}
+		authMiddleware = middleware
+	} else {
+		// No-op middleware if OIDC is not configured
+		authMiddleware = func(next http.Handler) http.Handler {
+			return next
+		}
+	}
 
-  return &AuthMux{
-    mux:            mux,
-    authMiddleware: authMiddleware,
-    serverConfig:   serverConfig,
-  }, nil
+	return &AuthMux{
+		mux:            mux,
+		authMiddleware: authMiddleware,
+		serverConfig:   serverConfig,
+	}, nil
 }
 
 // Handle registers a handler for the given pattern
 func (p *AuthMux) Handle(pattern string, handler http.Handler) {
-  p.mux.Handle(pattern, handler)
+	p.mux.Handle(pattern, handler)
 }
 
 // HandleFunc registers a handler function for the given pattern
 func (p *AuthMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-  p.mux.HandleFunc(pattern, handler)
+	p.mux.HandleFunc(pattern, handler)
 }
 
 // HandleProtected registers a protected handler for the given pattern
 func (p *AuthMux) HandleProtected(pattern string, handler http.Handler, checker iam.Checker, role string) {
-  // Apply CORS if origins are configured
-  if len(p.serverConfig.CorsOrigins) > 0 {
-    c := cors.New(cors.Options{
-      AllowedOrigins: p.serverConfig.CorsOrigins,
-      AllowedMethods: connectcors.AllowedMethods(),
-      AllowedHeaders: connectcors.AllowedHeaders(),
-      ExposedHeaders: connectcors.ExposedHeaders(),
-      MaxAge:         7200, // 2 hours in seconds
-    })
-    handler = c.Handler(handler)
-  }
+	// Apply CORS if origins are configured
+	if len(p.serverConfig.CorsOrigins) > 0 {
+		c := cors.New(cors.Options{
+			AllowedOrigins: p.serverConfig.CorsOrigins,
+			AllowedMethods: connectcors.AllowedMethods(),
+			AllowedHeaders: connectcors.AllowedHeaders(),
+			ExposedHeaders: connectcors.ExposedHeaders(),
+			MaxAge:         7200, // 2 hours in seconds
+		})
+		handler = c.Handler(handler)
+	}
 
-  // We need to create a new Auth middleware that will apply the IAM checks specific to this handler
-  iamChecker := func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// We need to create a new Auth middleware that will apply the IAM checks specific to this handler
+	iamChecker := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-      log := logs.FromContext(r.Context())
-      idToken := getIDToken(r.Context())
-      if idToken == nil {
-        log.Info("Unauthorized: No session")
-        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-        return
-      }
+			log := logs.FromContext(r.Context())
+			idToken := getIDToken(r.Context())
+			if idToken == nil {
+				log.Info("Unauthorized: No session")
+				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+				return
+			}
 
-      claims, ok := idToken.Claims.(jwt.MapClaims)
-      if !ok {
-        log.Info("Unauthorized invalid claims")
-        http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
-        return
-      }
+			claims, ok := idToken.Claims.(jwt.MapClaims)
+			if !ok {
+				log.Info("Unauthorized invalid claims")
+				http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
+				return
+			}
 
-      email, ok := claims["email"].(string)
-      if !ok {
-        log.Info("Unauthorized: Missing email claim")
-        http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
-        return
-      }
+			email, ok := claims["email"].(string)
+			if !ok {
+				log.Info("Unauthorized: Missing email claim")
+				http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
+				return
+			}
 
-      if !checker.Check(email, role) {
-        log.Info("Unauthorized", "user", email, "role", role)
-        http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
-        return
-      }
+			if !checker.Check(email, role) {
+				log.Info("Unauthorized", "user", email, "role", role)
+				http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
+				return
+			}
 
-      // Get the IDToken from the context
-      next.ServeHTTP(w, r)
-    })
-  }
+			// Get the IDToken from the context
+			next.ServeHTTP(w, r)
+		})
+	}
 
-  // Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
-  p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
+	// Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
+	p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
 }
 
 // HandleProtectedFunc registers a protected handler function for the given pattern
 func (p *AuthMux) HandleProtectedFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-  p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
+	p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
 }
 
 // ServeHTTP implements http.Handler
 func (p *AuthMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-  p.mux.ServeHTTP(w, r)
+	p.mux.ServeHTTP(w, r)
 }
 
 // getIDToken retrieves the ID token from the context if there is one or nil
 func getIDToken(ctx context.Context) *jwt.Token {
-  idToken := ctx.Value(IDTokenKey)
-  if idToken == nil {
-    return nil
-  }
-  token, ok := idToken.(*jwt.Token)
-  if !ok {
-    log := zapr.NewLogger(zap.L())
-    log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
-    return nil
-  }
-  return token
+	idToken := ctx.Value(IDTokenKey)
+	if idToken == nil {
+		return nil
+	}
+	token, ok := idToken.(*jwt.Token)
+	if !ok {
+		log := zapr.NewLogger(zap.L())
+		log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
+		return nil
+	}
+	return token
 }

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -1,133 +1,137 @@
 package server
 
 import (
-	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"math/big"
-	"net/http"
-	"net/url"
-	"os"
-	"slices"
-	"strings"
-	"sync"
-	"time"
+  "context"
+  "crypto/rand"
+  "crypto/rsa"
+  "encoding/base64"
+  "encoding/json"
+  "fmt"
+  "math/big"
+  "net/http"
+  "net/url"
+  "os"
+  "slices"
+  "strings"
+  "sync"
+  "time"
 
-	"github.com/jlewi/cloud-assistant/app/pkg/iam"
-	"github.com/jlewi/cloud-assistant/app/pkg/logs"
+  "github.com/jlewi/cloud-assistant/app/pkg/iam"
+  "github.com/jlewi/cloud-assistant/app/pkg/logs"
 
-	connectcors "connectrpc.com/cors"
-	"github.com/go-logr/zapr"
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/jlewi/cloud-assistant/app/pkg/config"
-	"github.com/pkg/errors"
-	"github.com/rs/cors"
-	"go.uber.org/zap"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
+  connectcors "connectrpc.com/cors"
+  "github.com/go-logr/zapr"
+  "github.com/golang-jwt/jwt/v5"
+  "github.com/jlewi/cloud-assistant/app/pkg/config"
+  "github.com/pkg/errors"
+  "github.com/rs/cors"
+  "go.uber.org/zap"
+  "golang.org/x/oauth2"
+  "golang.org/x/oauth2/google"
 )
 
+// IDTokenKeyType  string is the key used to store the ID token in the context
+// We define a type to avoid collisions with other context keys
+type IDTokenKeyType string
+
 const (
-	oidcPathPrefix    = "/oidc"
-	sessionCookieName = "cassie-session"
-	stateLength       = 32
-	IDTokenKey        = "idToken"
+  oidcPathPrefix                   = "/oidc"
+  sessionCookieName                = "cassie-session"
+  stateLength                      = 32
+  IDTokenKey        IDTokenKeyType = "idToken"
 )
 
 // OIDC handles OAuth2 authentication setup and management
 type OIDC struct {
-	config     *config.OIDCConfig
-	oauth2     *oauth2.Config
-	publicKeys map[string]*rsa.PublicKey
-	discovery  *openIDDiscovery
-	state      *stateManager
-	provider   OIDCProvider
+  config     *config.OIDCConfig
+  oauth2     *oauth2.Config
+  publicKeys map[string]*rsa.PublicKey
+  discovery  *openIDDiscovery
+  state      *stateManager
+  provider   OIDCProvider
 }
 
 // newOIDC creates a new OIDC
 func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
-	if cfg == nil {
-		return nil, nil
-	}
+  if cfg == nil {
+    return nil, nil
+  }
 
-	// Check that only one provider is configured
-	if cfg.Google != nil && cfg.Generic != nil {
-		return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
-	}
+  // Check that only one provider is configured
+  if cfg.Google != nil && cfg.Generic != nil {
+    return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
+  }
 
-	if cfg.Google == nil && cfg.Generic == nil {
-		return nil, nil
-	}
+  if cfg.Google == nil && cfg.Generic == nil {
+    return nil, nil
+  }
 
-	var provider OIDCProvider
-	if cfg.Google != nil {
-		provider = NewGoogleProvider(cfg.Google)
-	} else {
-		provider = NewGenericProvider(cfg.Generic)
-	}
+  var provider OIDCProvider
+  if cfg.Google != nil {
+    provider = NewGoogleProvider(cfg.Google)
+  } else {
+    provider = NewGenericProvider(cfg.Generic)
+  }
 
-	oauth2Config, err := provider.GetOAuth2Config()
-	if err != nil {
-		return nil, err
-	}
+  oauth2Config, err := provider.GetOAuth2Config()
+  if err != nil {
+    return nil, err
+  }
 
-	discoveryURL := provider.GetDiscoveryURL()
+  discoveryURL := provider.GetDiscoveryURL()
 
-	// Fetch the OpenID configuration
-	resp, err := http.Get(discoveryURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			zap.L().Error("failed to close response body", zap.Error(err))
-		}
-	}()
+  // Fetch the OpenID configuration
+  resp, err := http.Get(discoveryURL)
+  if err != nil {
+    return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
+  }
+  defer func() {
+    if err := resp.Body.Close(); err != nil {
+      zap.L().Error("failed to close response body", zap.Error(err))
+    }
+  }()
 
-	var discovery openIDDiscovery
-	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
-		return nil, errors.Wrap(err, "failed to decode OpenID configuration")
-	}
+  var discovery openIDDiscovery
+  if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+    return nil, errors.Wrap(err, "failed to decode OpenID configuration")
+  }
 
-	// Update endpoints from discovery document
-	oauth2Config.Endpoint = oauth2.Endpoint{
-		AuthURL:  discovery.AuthURL,
-		TokenURL: discovery.TokenURL,
-	}
+  // Update endpoints from discovery document
+  oauth2Config.Endpoint = oauth2.Endpoint{
+    AuthURL:  discovery.AuthURL,
+    TokenURL: discovery.TokenURL,
+  }
 
-	// If the generic provider is configured with an issuer, use it
-	if cfg.Generic != nil && cfg.Generic.Issuer != "" {
-		discovery.Issuer = cfg.Generic.Issuer
-	}
+  // If the generic provider is configured with an issuer, use it
+  if cfg.Generic != nil && cfg.Generic.Issuer != "" {
+    discovery.Issuer = cfg.Generic.Issuer
+  }
 
-	// Initialize OIDC
-	oidc := &OIDC{
-		config:     cfg,
-		oauth2:     oauth2Config,
-		publicKeys: make(map[string]*rsa.PublicKey),
-		discovery:  &discovery,
-		state:      newStateManager(10 * time.Minute),
-		provider:   provider,
-	}
+  // Initialize OIDC
+  oidc := &OIDC{
+    config:     cfg,
+    oauth2:     oauth2Config,
+    publicKeys: make(map[string]*rsa.PublicKey),
+    discovery:  &discovery,
+    state:      newStateManager(10 * time.Minute),
+    provider:   provider,
+  }
 
-	// Download JWKS for signature verification
-	if err := oidc.downloadJWKS(); err != nil {
-		return nil, errors.Wrapf(err, "Failed to download JWKS")
-	}
+  // Download JWKS for signature verification
+  if err := oidc.downloadJWKS(); err != nil {
+    return nil, errors.Wrapf(err, "Failed to download JWKS")
+  }
 
-	// Start a goroutine to clean up expired states
-	go func() {
-		ticker := time.NewTicker(oidc.state.stateExpiration / 2)
-		defer ticker.Stop()
-		for range ticker.C {
-			oidc.state.cleanupExpiredStates()
-		}
-	}()
+  // Start a goroutine to clean up expired states
+  go func() {
+    ticker := time.NewTicker(oidc.state.stateExpiration / 2)
+    defer ticker.Stop()
+    for range ticker.C {
+      oidc.state.cleanupExpiredStates()
+    }
+  }()
 
-	return oidc, nil
+  return oidc, nil
 }
 
 // downloadJWKS downloads the JSON Web Key Set (JWKS) from Google's OAuth2 provider.
@@ -136,601 +140,601 @@ func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
 // This allows the application to verify tokens offline without contacting Google's servers
 // for each verification request.
 func (o *OIDC) downloadJWKS() error {
-	// Fetch the JWKS from the URI specified in the discovery document
-	resp, err := http.Get(o.discovery.JWKSURI)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
-	}
-	defer func() {
-		if err := resp.Body.Close(); err != nil {
-			zap.L().Error("failed to close response body", zap.Error(err))
-		}
-	}()
+  // Fetch the JWKS from the URI specified in the discovery document
+  resp, err := http.Get(o.discovery.JWKSURI)
+  if err != nil {
+    return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
+  }
+  defer func() {
+    if err := resp.Body.Close(); err != nil {
+      zap.L().Error("failed to close response body", zap.Error(err))
+    }
+  }()
 
-	// Parse the JWKS into our structured format
-	var jwks jwks
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-		return errors.Wrapf(err, "Failed to parse JWKS response")
-	}
+  // Parse the JWKS into our structured format
+  var jwks jwks
+  if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+    return errors.Wrapf(err, "Failed to parse JWKS response")
+  }
 
-	// Convert each key to RSA public key and store in the map
-	for _, key := range jwks.Keys {
-		// Convert the modulus and exponent from base64url to *rsa.PublicKey
-		n, err := base64.RawURLEncoding.DecodeString(key.N)
-		if err != nil {
-			return errors.Wrap(err, "failed to decode modulus")
-		}
+  // Convert each key to RSA public key and store in the map
+  for _, key := range jwks.Keys {
+    // Convert the modulus and exponent from base64url to *rsa.PublicKey
+    n, err := base64.RawURLEncoding.DecodeString(key.N)
+    if err != nil {
+      return errors.Wrap(err, "failed to decode modulus")
+    }
 
-		e, err := base64.RawURLEncoding.DecodeString(key.E)
-		if err != nil {
-			return errors.Wrap(err, "failed to decode exponent")
-		}
+    e, err := base64.RawURLEncoding.DecodeString(key.E)
+    if err != nil {
+      return errors.Wrap(err, "failed to decode exponent")
+    }
 
-		// Convert the modulus to a big integer
-		modulus := new(big.Int).SetBytes(n)
+    // Convert the modulus to a big integer
+    modulus := new(big.Int).SetBytes(n)
 
-		// Convert the exponent to an integer
-		var exponent int
-		if len(e) < 4 {
-			for i := range e {
-				exponent = exponent<<8 + int(e[i])
-			}
-		} else {
-			return errors.New("exponent too large")
-		}
+    // Convert the exponent to an integer
+    var exponent int
+    if len(e) < 4 {
+      for i := range e {
+        exponent = exponent<<8 + int(e[i])
+      }
+    } else {
+      return errors.New("exponent too large")
+    }
 
-		// Create the RSA public key
-		publicKey := &rsa.PublicKey{
-			N: modulus,
-			E: exponent,
-		}
+    // Create the RSA public key
+    publicKey := &rsa.PublicKey{
+      N: modulus,
+      E: exponent,
+    }
 
-		// Store the public key in the map using the kid as the key
-		o.publicKeys[key.Kid] = publicKey
-	}
+    // Store the public key in the map using the kid as the key
+    o.publicKeys[key.Kid] = publicKey
+  }
 
-	return nil
+  return nil
 }
 
 // verifyToken verifies the JWT token and returns whether it's valid and any error encountered
 // result is nil if its an invalid token and non-nil if its valid
 func (o *OIDC) verifyToken(idToken string) (*jwt.Token, error) {
-	// Verify the token signature using JWKS
-	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
-		// Verify the signing method is what we expect
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
+  // Verify the token signature using JWKS
+  token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+    // Verify the signing method is what we expect
+    if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+      return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+    }
 
-		// Get the key ID from the token header
-		kid, ok := token.Header["kid"].(string)
-		if !ok {
-			return nil, errors.New("kid header not found in token")
-		}
+    // Get the key ID from the token header
+    kid, ok := token.Header["kid"].(string)
+    if !ok {
+      return nil, errors.New("kid header not found in token")
+    }
 
-		// Get the public key from our map
-		publicKey, ok := o.publicKeys[kid]
-		if !ok {
-			return nil, errors.New("unable to find appropriate key")
-		}
+    // Get the public key from our map
+    publicKey, ok := o.publicKeys[kid]
+    if !ok {
+      return nil, errors.New("unable to find appropriate key")
+    }
 
-		return publicKey, nil
-	})
+    return publicKey, nil
+  })
 
-	if err != nil || !token.Valid {
-		return nil, fmt.Errorf("invalid token signature: %v", err)
-	}
+  if err != nil || !token.Valid {
+    return nil, fmt.Errorf("invalid token signature: %v", err)
+  }
 
-	// Get the claims from the token
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, errors.New("failed to get claims from token")
-	}
+  // Get the claims from the token
+  claims, ok := token.Claims.(jwt.MapClaims)
+  if !ok {
+    return nil, errors.New("failed to get claims from token")
+  }
 
-	// Verify expiration
-	exp, err := claims.GetExpirationTime()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
-	}
-	if time.Now().After(exp.Time) {
-		return nil, errors.New("token expired")
-	}
+  // Verify expiration
+  exp, err := claims.GetExpirationTime()
+  if err != nil {
+    return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
+  }
+  if time.Now().After(exp.Time) {
+    return nil, errors.New("token expired")
+  }
 
-	// Verify issuer
-	iss, err := claims.GetIssuer()
-	if err != nil || iss != o.discovery.Issuer {
-		return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
-	}
+  // Verify issuer
+  iss, err := claims.GetIssuer()
+  if err != nil || iss != o.discovery.Issuer {
+    return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
+  }
 
-	// Verify audience matches our client ID
-	aud, err := claims.GetAudience()
-	if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
-		return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
-	}
+  // Verify audience matches our client ID
+  aud, err := claims.GetAudience()
+  if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
+    return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
+  }
 
-	return token, nil
+  return token, nil
 }
 
 // RegisterAuthRoutes registers the OAuth2 authentication routes
 func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
-	if config == nil {
-		return nil
-	}
+  if config == nil {
+    return nil
+  }
 
-	oidc, err := newOIDC(config)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to create OAuth2 manager")
-	}
+  oidc, err := newOIDC(config)
+  if err != nil {
+    return errors.Wrapf(err, "Failed to create OAuth2 manager")
+  }
 
-	// Register OAuth2 endpoints
-	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
-	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
-	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
-	mux.HandleFunc("/logout", oidc.logoutHandler)
+  // Register OAuth2 endpoints
+  mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
+  mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
+  mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
+  mux.HandleFunc("/logout", oidc.logoutHandler)
 
-	return nil
+  return nil
 }
 
 // NewAuthMiddleware creates a middleware that enforces OIDC authentication
 func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handler, error) {
-	if config == nil {
-		// Return a no-op middleware if OIDC is not configured
-		return func(next http.Handler) http.Handler {
-			return next
-		}, nil
-	}
+  if config == nil {
+    // Return a no-op middleware if OIDC is not configured
+    return func(next http.Handler) http.Handler {
+      return next
+    }, nil
+  }
 
-	oidc, err := newOIDC(config)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
-	}
-	return newAuthMiddlewareForOIDC(oidc)
+  oidc, err := newOIDC(config)
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
+  }
+  return newAuthMiddlewareForOIDC(oidc)
 }
 
 // newAuthMiddlewareForOIDC allows our test to inject a mock OIDC
 func newAuthMiddlewareForOIDC(oidc *OIDC) (func(http.Handler) http.Handler, error) {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			log := zapr.NewLogger(zap.L())
+  return func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+      log := zapr.NewLogger(zap.L())
 
-			// Skip authentication for login page and OAuth2 endpoints
-			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
-				next.ServeHTTP(w, r)
-				return
-			}
+      // Skip authentication for login page and OAuth2 endpoints
+      if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
+        next.ServeHTTP(w, r)
+        return
+      }
 
-			// Get the session token from the cookie
-			cookie, err := r.Cookie(sessionCookieName)
-			if err != nil {
-				// No session cookie, return 401 Unauthorized
-				log.Error(err, "No session cookie found")
-				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-				return
-			}
+      // Get the session token from the cookie
+      cookie, err := r.Cookie(sessionCookieName)
+      if err != nil {
+        // No session cookie, return 401 Unauthorized
+        log.Error(err, "No session cookie found")
+        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+        return
+      }
 
-			// Verify the token by parsing and validating the JWT
-			idToken := cookie.Value
+      // Verify the token by parsing and validating the JWT
+      idToken := cookie.Value
 
-			token, err := oidc.verifyToken(idToken)
-			if token == nil {
-				log.Error(err, "Token validation failed")
-				// Return HTTP 401 and let the client handle the redirect to the login page
-				http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
-				return
-			}
+      token, err := oidc.verifyToken(idToken)
+      if token == nil {
+        log.Error(err, "Token validation failed")
+        // Return HTTP 401 and let the client handle the redirect to the login page
+        http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
+        return
+      }
 
-			// Add the IDToken to the context
-			ctx := context.WithValue(r.Context(), IDTokenKey, token)
+      // Add the IDToken to the context
+      ctx := context.WithValue(r.Context(), IDTokenKey, token)
 
-			// Token is valid, proceed with the request
-			next.ServeHTTP(w, r.WithContext(ctx))
-		})
-	}, nil
+      // Token is valid, proceed with the request
+      next.ServeHTTP(w, r.WithContext(ctx))
+    })
+  }, nil
 }
 
 // loginHandler handles the OAuth2 login flow
 func (o *OIDC) loginHandler(w http.ResponseWriter, r *http.Request) {
-	state, err := o.state.generateState()
-	if err != nil {
-		log := zapr.NewLogger(zap.L())
-		log.Error(err, "Failed to generate state")
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-	url := o.oauth2.AuthCodeURL(state)
-	if o.config.ForceApproval {
-		url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
-	}
-	http.Redirect(w, r, url, http.StatusFound)
+  state, err := o.state.generateState()
+  if err != nil {
+    log := zapr.NewLogger(zap.L())
+    log.Error(err, "Failed to generate state")
+    http.Error(w, "Internal server error", http.StatusInternalServerError)
+    return
+  }
+  url := o.oauth2.AuthCodeURL(state)
+  if o.config.ForceApproval {
+    url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
+  }
+  http.Redirect(w, r, url, http.StatusFound)
 }
 
 // callbackHandler handles the OAuth2 callback
 func (o *OIDC) callbackHandler(w http.ResponseWriter, r *http.Request) {
-	log := zapr.NewLogger(zap.L())
+  log := zapr.NewLogger(zap.L())
 
-	// Verify state
-	state := r.URL.Query().Get("state")
-	if !o.state.validateState(state) {
-		log.Error(nil, "Invalid state parameter")
-		redirectWithError(w, r, "invalid_state", "Invalid state parameter")
-		return
-	}
+  // Verify state
+  state := r.URL.Query().Get("state")
+  if !o.state.validateState(state) {
+    log.Error(nil, "Invalid state parameter")
+    redirectWithError(w, r, "invalid_state", "Invalid state parameter")
+    return
+  }
 
-	// Exchange code for token
-	code := r.URL.Query().Get("code")
-	token, err := o.oauth2.Exchange(r.Context(), code)
-	if err != nil {
-		log.Error(err, "Failed to exchange code for token")
-		redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
-		return
-	}
+  // Exchange code for token
+  code := r.URL.Query().Get("code")
+  token, err := o.oauth2.Exchange(r.Context(), code)
+  if err != nil {
+    log.Error(err, "Failed to exchange code for token")
+    redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
+    return
+  }
 
-	// Get the ID token from the response
-	idToken, ok := token.Extra("id_token").(string)
-	if !ok {
-		log.Error(nil, "No ID token in response")
-		redirectWithError(w, r, "no_id_token", "No ID token in response")
-		return
-	}
+  // Get the ID token from the response
+  idToken, ok := token.Extra("id_token").(string)
+  if !ok {
+    log.Error(nil, "No ID token in response")
+    redirectWithError(w, r, "no_id_token", "No ID token in response")
+    return
+  }
 
-	// Set the session cookie with the ID token
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    idToken,
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-	})
+  // Set the session cookie with the ID token
+  http.SetCookie(w, &http.Cookie{
+    Name:     sessionCookieName,
+    Value:    idToken,
+    Path:     "/",
+    HttpOnly: true,
+    Secure:   true,
+    SameSite: http.SameSiteLaxMode,
+  })
 
-	// Redirect to the home page
-	http.Redirect(w, r, "/", http.StatusFound)
+  // Redirect to the home page
+  http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // redirectWithError redirects to the login page with error information
 func redirectWithError(w http.ResponseWriter, r *http.Request, errorCode, errorDescription string) {
-	// Get any existing error parameters from the request
-	existingError := r.URL.Query().Get("error")
-	existingDescription := r.URL.Query().Get("error_description")
+  // Get any existing error parameters from the request
+  existingError := r.URL.Query().Get("error")
+  existingDescription := r.URL.Query().Get("error_description")
 
-	// Use existing error parameters if they exist, otherwise use the provided ones
-	if existingError == "" {
-		existingError = errorCode
-	}
-	if existingDescription == "" {
-		existingDescription = errorDescription
-	}
+  // Use existing error parameters if they exist, otherwise use the provided ones
+  if existingError == "" {
+    existingError = errorCode
+  }
+  if existingDescription == "" {
+    existingDescription = errorDescription
+  }
 
-	// Build the redirect URL with error parameters
-	redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
-		url.QueryEscape(existingError),
-		url.QueryEscape(existingDescription))
+  // Build the redirect URL with error parameters
+  redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
+    url.QueryEscape(existingError),
+    url.QueryEscape(existingDescription))
 
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+  http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // logoutHandler handles the OAuth2 logout
 func (o *OIDC) logoutHandler(w http.ResponseWriter, r *http.Request) {
-	// Clear the session cookie
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    "",
-		Path:     "/",
-		HttpOnly: true,
-		Secure:   true,
-		SameSite: http.SameSiteLaxMode,
-		MaxAge:   -1,
-	})
+  // Clear the session cookie
+  http.SetCookie(w, &http.Cookie{
+    Name:     sessionCookieName,
+    Value:    "",
+    Path:     "/",
+    HttpOnly: true,
+    Secure:   true,
+    SameSite: http.SameSiteLaxMode,
+    MaxAge:   -1,
+  })
 
-	// Redirect to the home page
-	http.Redirect(w, r, "/", http.StatusFound)
+  // Redirect to the home page
+  http.Redirect(w, r, "/", http.StatusFound)
 }
 
 type stateEntry struct {
-	expiresAt time.Time
+  expiresAt time.Time
 }
 
 type stateManager struct {
-	stateExpiration time.Duration
-	states          map[string]stateEntry
-	mu              sync.RWMutex
+  stateExpiration time.Duration
+  states          map[string]stateEntry
+  mu              sync.RWMutex
 }
 
 func newStateManager(stateExpiration time.Duration) *stateManager {
-	return &stateManager{
-		stateExpiration: stateExpiration,
-		states:          make(map[string]stateEntry),
-	}
+  return &stateManager{
+    stateExpiration: stateExpiration,
+    states:          make(map[string]stateEntry),
+  }
 }
 
 // generateState generates a new cryptographically secure random state
 func (sm *stateManager) generateState() (string, error) {
-	b := make([]byte, stateLength)
-	if _, err := rand.Read(b); err != nil {
-		return "", errors.Wrap(err, "failed to generate random state")
-	}
-	state := base64.URLEncoding.EncodeToString(b)
+  b := make([]byte, stateLength)
+  if _, err := rand.Read(b); err != nil {
+    return "", errors.Wrap(err, "failed to generate random state")
+  }
+  state := base64.URLEncoding.EncodeToString(b)
 
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
-	sm.states[state] = stateEntry{
-		expiresAt: time.Now().Add(sm.stateExpiration),
-	}
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
+  sm.states[state] = stateEntry{
+    expiresAt: time.Now().Add(sm.stateExpiration),
+  }
 
-	return state, nil
+  return state, nil
 }
 
 // validateState checks if a state is valid and removes it if it is
 func (sm *stateManager) validateState(state string) bool {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
 
-	entry, exists := sm.states[state]
-	if !exists {
-		return false
-	}
+  entry, exists := sm.states[state]
+  if !exists {
+    return false
+  }
 
-	// Remove the state regardless of validity
-	delete(sm.states, state)
+  // Remove the state regardless of validity
+  delete(sm.states, state)
 
-	// Check if the state has expired
-	return time.Now().Before(entry.expiresAt)
+  // Check if the state has expired
+  return time.Now().Before(entry.expiresAt)
 }
 
 // cleanupExpiredStates removes expired states from the map
 func (sm *stateManager) cleanupExpiredStates() {
-	sm.mu.Lock()
-	defer sm.mu.Unlock()
+  sm.mu.Lock()
+  defer sm.mu.Unlock()
 
-	now := time.Now()
-	for state, entry := range sm.states {
-		if now.After(entry.expiresAt) {
-			delete(sm.states, state)
-		}
-	}
+  now := time.Now()
+  for state, entry := range sm.states {
+    if now.After(entry.expiresAt) {
+      delete(sm.states, state)
+    }
+  }
 }
 
 // jwksKey represents a single key in the JWKS
 type jwksKey struct {
-	Kty string `json:"kty"`
-	Alg string `json:"alg"`
-	Use string `json:"use"`
-	Kid string `json:"kid"`
-	N   string `json:"n"`
-	E   string `json:"e"`
+  Kty string `json:"kty"`
+  Alg string `json:"alg"`
+  Use string `json:"use"`
+  Kid string `json:"kid"`
+  N   string `json:"n"`
+  E   string `json:"e"`
 }
 
 // jwks represents the JSON Web Key Set
 type jwks struct {
-	Keys []jwksKey `json:"keys"`
+  Keys []jwksKey `json:"keys"`
 }
 
 // openIDDiscovery is the struct for parsing the discovery document
 type openIDDiscovery struct {
-	Issuer                           string   `json:"issuer"`
-	AuthURL                          string   `json:"authorization_endpoint"`
-	TokenURL                         string   `json:"token_endpoint"`
-	JWKSURI                          string   `json:"jwks_uri"`
-	UserInfoURL                      string   `json:"userinfo_endpoint"`
-	ScopesSupported                  []string `json:"scopes_supported"`
-	ResponseTypesSupported           []string `json:"response_types_supported"`
-	SubjectTypesSupported            []string `json:"subject_types_supported"`
-	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+  Issuer                           string   `json:"issuer"`
+  AuthURL                          string   `json:"authorization_endpoint"`
+  TokenURL                         string   `json:"token_endpoint"`
+  JWKSURI                          string   `json:"jwks_uri"`
+  UserInfoURL                      string   `json:"userinfo_endpoint"`
+  ScopesSupported                  []string `json:"scopes_supported"`
+  ResponseTypesSupported           []string `json:"response_types_supported"`
+  SubjectTypesSupported            []string `json:"subject_types_supported"`
+  IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // OIDCProvider defines the interface for OIDC providers
 type OIDCProvider interface {
-	// GetOAuth2Config returns the OAuth2 configuration
-	GetOAuth2Config() (*oauth2.Config, error)
-	// GetDiscoveryURL returns the OpenID Connect discovery URL
-	GetDiscoveryURL() string
+  // GetOAuth2Config returns the OAuth2 configuration
+  GetOAuth2Config() (*oauth2.Config, error)
+  // GetDiscoveryURL returns the OpenID Connect discovery URL
+  GetDiscoveryURL() string
 }
 
 // GoogleProvider implements OIDCProvider for Google OAuth2
 type GoogleProvider struct {
-	config *config.GoogleOIDCConfig
+  config *config.GoogleOIDCConfig
 }
 
 func NewGoogleProvider(cfg *config.GoogleOIDCConfig) *GoogleProvider {
-	return &GoogleProvider{config: cfg}
+  return &GoogleProvider{config: cfg}
 }
 
 func (p *GoogleProvider) GetOAuth2Config() (*oauth2.Config, error) {
-	bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to read client credentials file")
-	}
+  bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to read client credentials file")
+  }
 
-	config, err := google.ConfigFromJSON(bytes, "openid", "email")
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
-	}
-	return config, nil
+  config, err := google.ConfigFromJSON(bytes, "openid", "email")
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
+  }
+  return config, nil
 }
 
 func (p *GoogleProvider) GetDiscoveryURL() string {
-	return p.config.GetDiscoveryURL()
+  return p.config.GetDiscoveryURL()
 }
 
 func (p *GoogleProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-	hd, ok := claims["hd"].(string)
-	if !ok {
-		return errors.New("missing hosted domain claim")
-	}
-	if hd != "" {
-		if !slices.Contains(allowedDomains, hd) {
-			return fmt.Errorf("hosted domain %v not in allowed domains", hd)
-		}
-	} else {
-		return errors.New("missing hosted domain claim")
-	}
-	return nil
+  hd, ok := claims["hd"].(string)
+  if !ok {
+    return errors.New("missing hosted domain claim")
+  }
+  if hd != "" {
+    if !slices.Contains(allowedDomains, hd) {
+      return fmt.Errorf("hosted domain %v not in allowed domains", hd)
+    }
+  } else {
+    return errors.New("missing hosted domain claim")
+  }
+  return nil
 }
 
 // GenericProvider implements OIDCProvider for generic OIDC providers
 type GenericProvider struct {
-	config *config.GenericOIDCConfig
+  config *config.GenericOIDCConfig
 }
 
 func NewGenericProvider(cfg *config.GenericOIDCConfig) *GenericProvider {
-	return &GenericProvider{config: cfg}
+  return &GenericProvider{config: cfg}
 }
 
 func (p *GenericProvider) GetOAuth2Config() (*oauth2.Config, error) {
-	return &oauth2.Config{
-		ClientID:     p.config.ClientID,
-		ClientSecret: p.config.ClientSecret,
-		RedirectURL:  p.config.RedirectURL,
-		Scopes:       p.config.Scopes,
-	}, nil
+  return &oauth2.Config{
+    ClientID:     p.config.ClientID,
+    ClientSecret: p.config.ClientSecret,
+    RedirectURL:  p.config.RedirectURL,
+    Scopes:       p.config.Scopes,
+  }, nil
 }
 
 func (p *GenericProvider) GetDiscoveryURL() string {
-	return p.config.GetDiscoveryURL()
+  return p.config.GetDiscoveryURL()
 }
 
 func (p *GenericProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-	email, ok := claims["email"].(string)
-	if !ok {
-		return errors.New("missing email claim")
-	}
+  email, ok := claims["email"].(string)
+  if !ok {
+    return errors.New("missing email claim")
+  }
 
-	if email == "" {
-		return errors.New("empty email claim")
-	}
+  if email == "" {
+    return errors.New("empty email claim")
+  }
 
-	parts := strings.Split(email, "@")
-	if len(parts) != 2 {
-		return errors.New("invalid email format")
-	}
+  parts := strings.Split(email, "@")
+  if len(parts) != 2 {
+    return errors.New("invalid email format")
+  }
 
-	emailDomain := parts[1]
-	if !slices.Contains(allowedDomains, emailDomain) {
-		return fmt.Errorf("email domain not in allowed domains: %s", email)
-	}
+  emailDomain := parts[1]
+  if !slices.Contains(allowedDomains, emailDomain) {
+    return fmt.Errorf("email domain not in allowed domains: %s", email)
+  }
 
-	return nil
+  return nil
 }
 
 // AuthMux wraps http.ServeMux to add protected route handling
 type AuthMux struct {
-	mux            *http.ServeMux
-	authMiddleware func(http.Handler) http.Handler
-	serverConfig   *config.AssistantServerConfig
+  mux            *http.ServeMux
+  authMiddleware func(http.Handler) http.Handler
+  serverConfig   *config.AssistantServerConfig
 }
 
 // NewAuthMux creates a new AuthMux
 func NewAuthMux(serverConfig *config.AssistantServerConfig) (*AuthMux, error) {
-	mux := http.NewServeMux()
+  mux := http.NewServeMux()
 
-	// Create auth middleware if OIDC is configured
-	var authMiddleware func(http.Handler) http.Handler
-	if serverConfig != nil && serverConfig.OIDC != nil {
-		middleware, err := NewAuthMiddleware(serverConfig.OIDC)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to create auth middleware")
-		}
-		authMiddleware = middleware
-	} else {
-		// No-op middleware if OIDC is not configured
-		authMiddleware = func(next http.Handler) http.Handler {
-			return next
-		}
-	}
+  // Create auth middleware if OIDC is configured
+  var authMiddleware func(http.Handler) http.Handler
+  if serverConfig != nil && serverConfig.OIDC != nil {
+    middleware, err := NewAuthMiddleware(serverConfig.OIDC)
+    if err != nil {
+      return nil, errors.Wrapf(err, "Failed to create auth middleware")
+    }
+    authMiddleware = middleware
+  } else {
+    // No-op middleware if OIDC is not configured
+    authMiddleware = func(next http.Handler) http.Handler {
+      return next
+    }
+  }
 
-	return &AuthMux{
-		mux:            mux,
-		authMiddleware: authMiddleware,
-		serverConfig:   serverConfig,
-	}, nil
+  return &AuthMux{
+    mux:            mux,
+    authMiddleware: authMiddleware,
+    serverConfig:   serverConfig,
+  }, nil
 }
 
 // Handle registers a handler for the given pattern
 func (p *AuthMux) Handle(pattern string, handler http.Handler) {
-	p.mux.Handle(pattern, handler)
+  p.mux.Handle(pattern, handler)
 }
 
 // HandleFunc registers a handler function for the given pattern
 func (p *AuthMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	p.mux.HandleFunc(pattern, handler)
+  p.mux.HandleFunc(pattern, handler)
 }
 
 // HandleProtected registers a protected handler for the given pattern
 func (p *AuthMux) HandleProtected(pattern string, handler http.Handler, checker iam.Checker, role string) {
-	// Apply CORS if origins are configured
-	if len(p.serverConfig.CorsOrigins) > 0 {
-		c := cors.New(cors.Options{
-			AllowedOrigins: p.serverConfig.CorsOrigins,
-			AllowedMethods: connectcors.AllowedMethods(),
-			AllowedHeaders: connectcors.AllowedHeaders(),
-			ExposedHeaders: connectcors.ExposedHeaders(),
-			MaxAge:         7200, // 2 hours in seconds
-		})
-		handler = c.Handler(handler)
-	}
+  // Apply CORS if origins are configured
+  if len(p.serverConfig.CorsOrigins) > 0 {
+    c := cors.New(cors.Options{
+      AllowedOrigins: p.serverConfig.CorsOrigins,
+      AllowedMethods: connectcors.AllowedMethods(),
+      AllowedHeaders: connectcors.AllowedHeaders(),
+      ExposedHeaders: connectcors.ExposedHeaders(),
+      MaxAge:         7200, // 2 hours in seconds
+    })
+    handler = c.Handler(handler)
+  }
 
-	// We need to create a new Auth middleware that will apply the IAM checks specific to this handler
-	iamChecker := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+  // We need to create a new Auth middleware that will apply the IAM checks specific to this handler
+  iamChecker := func(next http.Handler) http.Handler {
+    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-			log := logs.FromContext(r.Context())
-			idToken := getIDToken(r.Context())
-			if idToken == nil {
-				log.Info("Unauthorized: No session")
-				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-				return
-			}
+      log := logs.FromContext(r.Context())
+      idToken := getIDToken(r.Context())
+      if idToken == nil {
+        log.Info("Unauthorized: No session")
+        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+        return
+      }
 
-			claims, ok := idToken.Claims.(jwt.MapClaims)
-			if !ok {
-				log.Info("Unauthorized invalid claims")
-				http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
-				return
-			}
+      claims, ok := idToken.Claims.(jwt.MapClaims)
+      if !ok {
+        log.Info("Unauthorized invalid claims")
+        http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
+        return
+      }
 
-			email, ok := claims["email"].(string)
-			if !ok {
-				log.Info("Unauthorized: Missing email claim")
-				http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
-				return
-			}
+      email, ok := claims["email"].(string)
+      if !ok {
+        log.Info("Unauthorized: Missing email claim")
+        http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
+        return
+      }
 
-			if !checker.Check(email, role) {
-				log.Info("Unauthorized", "user", email, "role", role)
-				http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
-				return
-			}
+      if !checker.Check(email, role) {
+        log.Info("Unauthorized", "user", email, "role", role)
+        http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
+        return
+      }
 
-			// Get the IDToken from the context
-			next.ServeHTTP(w, r)
-		})
-	}
+      // Get the IDToken from the context
+      next.ServeHTTP(w, r)
+    })
+  }
 
-	// Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
-	p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
+  // Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
+  p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
 }
 
 // HandleProtectedFunc registers a protected handler function for the given pattern
 func (p *AuthMux) HandleProtectedFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-	p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
+  p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
 }
 
 // ServeHTTP implements http.Handler
 func (p *AuthMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	p.mux.ServeHTTP(w, r)
+  p.mux.ServeHTTP(w, r)
 }
 
 // getIDToken retrieves the ID token from the context if there is one or nil
 func getIDToken(ctx context.Context) *jwt.Token {
-	idToken := ctx.Value(IDTokenKey)
-	if idToken == nil {
-		return nil
-	}
-	token, ok := idToken.(*jwt.Token)
-	if !ok {
-		log := zapr.NewLogger(zap.L())
-		log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
-		return nil
-	}
-	return token
+  idToken := ctx.Value(IDTokenKey)
+  if idToken == nil {
+    return nil
+  }
+  token, ok := idToken.(*jwt.Token)
+  if !ok {
+    log := zapr.NewLogger(zap.L())
+    log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
+    return nil
+  }
+  return token
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -1,717 +1,703 @@
 package server
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
-	"encoding/base64"
-	"encoding/json"
-	"io"
-	"math/big"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"testing"
-	"time"
+  "crypto/rand"
+  "crypto/rsa"
+  "encoding/base64"
+  "encoding/json"
+  "io"
+  "math/big"
+  "net/http"
+  "net/http/httptest"
+  "net/url"
+  "testing"
+  "time"
 
-	"github.com/pkg/errors"
+  "github.com/pkg/errors"
 
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/jlewi/cloud-assistant/app/pkg/config"
+  "github.com/golang-jwt/jwt/v5"
+  "github.com/jlewi/cloud-assistant/app/pkg/config"
 )
 
 func TestStateManager(t *testing.T) {
-	sm := newStateManager(6 * time.Second)
+  sm := newStateManager(6 * time.Second)
 
-	// Test state generation
-	state, err := sm.generateState()
-	if err != nil {
-		t.Fatalf("Failed to generate state: %v", err)
-	}
-	if state == "" {
-		t.Error("Generated state is empty")
-	}
+  // Test state generation
+  state, err := sm.generateState()
+  if err != nil {
+    t.Fatalf("Failed to generate state: %v", err)
+  }
+  if state == "" {
+    t.Error("Generated state is empty")
+  }
 
-	// Test state validation
-	if !sm.validateState(state) {
-		t.Error("Valid state was not accepted")
-	}
-	if sm.validateState(state) {
-		t.Error("State was accepted twice")
-	}
+  // Test state validation
+  if !sm.validateState(state) {
+    t.Error("Valid state was not accepted")
+  }
+  if sm.validateState(state) {
+    t.Error("State was accepted twice")
+  }
 
-	// Test state expiration
-	state, err = sm.generateState()
-	if err != nil {
-		t.Fatalf("Failed to generate state: %v", err)
-	}
-	time.Sleep(sm.stateExpiration + time.Second)
-	if sm.validateState(state) {
-		t.Error("Expired state was accepted")
-	}
+  // Test state expiration
+  state, err = sm.generateState()
+  if err != nil {
+    t.Fatalf("Failed to generate state: %v", err)
+  }
+  time.Sleep(sm.stateExpiration + time.Second)
+  if sm.validateState(state) {
+    t.Error("Expired state was accepted")
+  }
 }
 
 func TestOIDC_NewOIDC(t *testing.T) {
-	// Test with nil config
-	oidc, err := newOIDC(nil)
-	if err != nil {
-		t.Errorf("Expected no error with nil config, got %v", err)
-	}
-	if oidc != nil {
-		t.Error("Expected nil OIDC with nil config")
-	}
+  // Test with nil config
+  oidc, err := newOIDC(nil)
+  if err != nil {
+    t.Errorf("Expected no error with nil config, got %v", err)
+  }
+  if oidc != nil {
+    t.Error("Expected nil OIDC with nil config")
+  }
 
-	// Test with nil Google config
-	cfg := &config.OIDCConfig{}
-	oidc, err = newOIDC(cfg)
-	if err != nil {
-		t.Errorf("Expected no error with nil Google config, got %v", err)
-	}
-	if oidc != nil {
-		t.Error("Expected nil OIDC with nil Google config")
-	}
+  // Test with nil Google config
+  cfg := &config.OIDCConfig{}
+  oidc, err = newOIDC(cfg)
+  if err != nil {
+    t.Errorf("Expected no error with nil Google config, got %v", err)
+  }
+  if oidc != nil {
+    t.Error("Expected nil OIDC with nil Google config")
+  }
 
-	// Test with invalid config
-	cfg.Google = &config.GoogleOIDCConfig{
-		ClientCredentialsFile: "nonexistent.json",
-	}
-	oidc, err = newOIDC(cfg)
-	if err == nil {
-		t.Error("Expected error with invalid config")
-	}
-	if oidc != nil {
-		t.Error("Expected nil OIDC with invalid config")
-	}
+  // Test with invalid config
+  cfg.Google = &config.GoogleOIDCConfig{
+    ClientCredentialsFile: "nonexistent.json",
+  }
+  oidc, err = newOIDC(cfg)
+  if err == nil {
+    t.Error("Expected error with invalid config")
+  }
+  if oidc != nil {
+    t.Error("Expected nil OIDC with invalid config")
+  }
 }
 
 func TestOIDC_Handlers(t *testing.T) {
-	// Create a test OIDC instance
-	cfg := &config.OIDCConfig{
-		Google: &config.GoogleOIDCConfig{
-			ClientCredentialsFile: "testdata/google-client-dummy.json",
-			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-		},
-	}
-	oidc, err := newOIDC(cfg)
-	if err != nil {
-		t.Fatalf("Failed to create OIDC instance: %v", err)
-	}
+  // Create a test OIDC instance
+  cfg := &config.OIDCConfig{
+    Google: &config.GoogleOIDCConfig{
+      ClientCredentialsFile: "testdata/google-client-dummy.json",
+      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+    },
+  }
+  oidc, err := newOIDC(cfg)
+  if err != nil {
+    t.Fatalf("Failed to create OIDC instance: %v", err)
+  }
 
-	t.Run("LoginHandler", func(t *testing.T) {
-		// Create a test request
-		req := httptest.NewRequest("GET", "/oidc/login", nil)
-		w := httptest.NewRecorder()
+  t.Run("LoginHandler", func(t *testing.T) {
+    // Create a test request
+    req := httptest.NewRequest("GET", "/oidc/login", nil)
+    w := httptest.NewRecorder()
 
-		// Call the handler
-		oidc.loginHandler(w, req)
+    // Call the handler
+    oidc.loginHandler(w, req)
 
-		// Check the response
-		resp := w.Result()
-		if resp.StatusCode != http.StatusFound {
-			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-		}
+    // Check the response
+    resp := w.Result()
+    if resp.StatusCode != http.StatusFound {
+      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+    }
 
-		// Parse the redirect URL
-		redirectURL, err := url.Parse(resp.Header.Get("Location"))
-		if err != nil {
-			t.Fatalf("Failed to parse redirect URL: %v", err)
-		}
+    // Parse the redirect URL
+    redirectURL, err := url.Parse(resp.Header.Get("Location"))
+    if err != nil {
+      t.Fatalf("Failed to parse redirect URL: %v", err)
+    }
 
-		// Verify the URL contains required parameters
-		if redirectURL.Host != "accounts.google.com" {
-			t.Errorf("Expected host accounts.google.com, got %s", redirectURL.Host)
-		}
-		if clientID := redirectURL.Query().Get("client_id"); clientID != "dummy-client-id" {
-			t.Errorf("Expected client_id dummy-client-id, got %s", clientID)
-		}
-		if state := redirectURL.Query().Get("state"); state == "" {
-			t.Error("Expected non-empty state parameter")
-		}
-	})
+    // Verify the URL contains required parameters
+    if redirectURL.Host != "accounts.google.com" {
+      t.Errorf("Expected host accounts.google.com, got %s", redirectURL.Host)
+    }
+    if clientID := redirectURL.Query().Get("client_id"); clientID != "dummy-client-id" {
+      t.Errorf("Expected client_id dummy-client-id, got %s", clientID)
+    }
+    if state := redirectURL.Query().Get("state"); state == "" {
+      t.Error("Expected non-empty state parameter")
+    }
+  })
 
-	t.Run("CallbackHandler", func(t *testing.T) {
-		// Generate a valid state
-		state, err := oidc.state.generateState()
-		if err != nil {
-			t.Fatalf("Failed to generate state: %v", err)
-		}
+  t.Run("CallbackHandler", func(t *testing.T) {
+    // Generate a valid state
+    state, err := oidc.state.generateState()
+    if err != nil {
+      t.Fatalf("Failed to generate state: %v", err)
+    }
 
-		// Create a test request with invalid state
-		req := httptest.NewRequest("GET", "/oidc/callback?state=invalid&code=test-code", nil)
-		w := httptest.NewRecorder()
-		oidc.callbackHandler(w, req)
-		resp := w.Result()
-		if resp.StatusCode != http.StatusFound {
-			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-			return
-		}
+    // Create a test request with invalid state
+    req := httptest.NewRequest("GET", "/oidc/callback?state=invalid&code=test-code", nil)
+    w := httptest.NewRecorder()
+    oidc.callbackHandler(w, req)
+    resp := w.Result()
+    if resp.StatusCode != http.StatusFound {
+      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+      return
+    }
 
-		location := resp.Header.Get("Location")
-		expectedLocation := "/login?error=invalid_state&error_description=Invalid+state+parameter"
-		if location != expectedLocation {
-			t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
-		}
+    location := resp.Header.Get("Location")
+    expectedLocation := "/login?error=invalid_state&error_description=Invalid+state+parameter"
+    if location != expectedLocation {
+      t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
+    }
 
-		// Create a test request with valid state but no code
-		req = httptest.NewRequest("GET", "/oidc/callback?state="+state, nil)
-		w = httptest.NewRecorder()
-		oidc.callbackHandler(w, req)
-		resp = w.Result()
-		if resp.StatusCode != http.StatusFound {
-			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-			return
-		}
+    // Create a test request with valid state but no code
+    req = httptest.NewRequest("GET", "/oidc/callback?state="+state, nil)
+    w = httptest.NewRecorder()
+    oidc.callbackHandler(w, req)
+    resp = w.Result()
+    if resp.StatusCode != http.StatusFound {
+      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+      return
+    }
 
-		location = resp.Header.Get("Location")
-		expectedLocation = "/login?error=token_exchange_failed&error_description=Failed+to+exchange+code+for+token"
-		if location != expectedLocation {
-			t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
-		}
-	})
+    location = resp.Header.Get("Location")
+    expectedLocation = "/login?error=token_exchange_failed&error_description=Failed+to+exchange+code+for+token"
+    if location != expectedLocation {
+      t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
+    }
+  })
 
-	t.Run("LogoutHandler", func(t *testing.T) {
-		testPaths := []string{"/oidc/logout", "/logout"}
+  t.Run("LogoutHandler", func(t *testing.T) {
+    testPaths := []string{"/oidc/logout", "/logout"}
 
-		for _, path := range testPaths {
-			t.Run(path, func(t *testing.T) {
-				// Create a test request
-				req := httptest.NewRequest("GET", path, nil)
-				w := httptest.NewRecorder()
+    for _, path := range testPaths {
+      t.Run(path, func(t *testing.T) {
+        // Create a test request
+        req := httptest.NewRequest("GET", path, nil)
+        w := httptest.NewRecorder()
 
-				// Call the handler
-				oidc.logoutHandler(w, req)
+        // Call the handler
+        oidc.logoutHandler(w, req)
 
-				// Check the response
-				resp := w.Result()
-				if resp.StatusCode != http.StatusFound {
-					t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-				}
+        // Check the response
+        resp := w.Result()
+        if resp.StatusCode != http.StatusFound {
+          t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+        }
 
-				// Verify the cookie is cleared
-				cookies := resp.Cookies()
-				if len(cookies) != 1 {
-					t.Errorf("Expected 1 cookie, got %d", len(cookies))
-				}
-				cookie := cookies[0]
-				if cookie.Name != sessionCookieName {
-					t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
-				}
-				if cookie.Value != "" {
-					t.Error("Expected empty cookie value")
-				}
-				if cookie.MaxAge != -1 {
-					t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
-				}
-			})
-		}
-	})
+        // Verify the cookie is cleared
+        cookies := resp.Cookies()
+        if len(cookies) != 1 {
+          t.Errorf("Expected 1 cookie, got %d", len(cookies))
+        }
+        cookie := cookies[0]
+        if cookie.Name != sessionCookieName {
+          t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
+        }
+        if cookie.Value != "" {
+          t.Error("Expected empty cookie value")
+        }
+        if cookie.MaxAge != -1 {
+          t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+        }
+      })
+    }
+  })
 }
 
 func TestOIDC_DownloadJWKS(t *testing.T) {
-	// Create a test server to mock the JWKS endpoint
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Create a test RSA key
-		key := &rsa.PublicKey{
-			N: big.NewInt(12345),
-			E: 65537,
-		}
+  // Create a test server to mock the JWKS endpoint
+  ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    // Create a test RSA key
+    key := &rsa.PublicKey{
+      N: big.NewInt(12345),
+      E: 65537,
+    }
 
-		// Create a test JWKS response
-		jwks := &jwks{
-			Keys: []jwksKey{
-				{
-					Kty: "RSA",
-					Alg: "RS256",
-					Use: "sig",
-					Kid: "test-key",
-					N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
-					E:   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
-				},
-			},
-		}
+    // Create a test JWKS response
+    jwks := &jwks{
+      Keys: []jwksKey{
+        {
+          Kty: "RSA",
+          Alg: "RS256",
+          Use: "sig",
+          Kid: "test-key",
+          N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+          E:   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
+        },
+      },
+    }
 
-		if err := json.NewEncoder(w).Encode(jwks); err != nil {
-			http.Error(w, "failed to encode response", http.StatusInternalServerError)
-			return
-		}
-	}))
-	defer ts.Close()
+    if err := json.NewEncoder(w).Encode(jwks); err != nil {
+      http.Error(w, "failed to encode response", http.StatusInternalServerError)
+      return
+    }
+  }))
+  defer ts.Close()
 
-	// Create a test OIDC instance
-	cfg := &config.OIDCConfig{
-		Google: &config.GoogleOIDCConfig{
-			ClientCredentialsFile: "testdata/google-client-dummy.json",
-			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-		},
-	}
-	oidc, err := newOIDC(cfg)
-	if err != nil {
-		t.Fatalf("Failed to create OIDC instance: %v", err)
-	}
+  // Create a test OIDC instance
+  cfg := &config.OIDCConfig{
+    Google: &config.GoogleOIDCConfig{
+      ClientCredentialsFile: "testdata/google-client-dummy.json",
+      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+    },
+  }
+  oidc, err := newOIDC(cfg)
+  if err != nil {
+    t.Fatalf("Failed to create OIDC instance: %v", err)
+  }
 
-	// Override the discovery document with our test server URL
-	oidc.discovery.JWKSURI = ts.URL
+  // Override the discovery document with our test server URL
+  oidc.discovery.JWKSURI = ts.URL
 
-	// Download the JWKS
-	err = oidc.downloadJWKS()
-	if err != nil {
-		t.Fatalf("Failed to download JWKS: %v", err)
-	}
+  // Download the JWKS
+  err = oidc.downloadJWKS()
+  if err != nil {
+    t.Fatalf("Failed to download JWKS: %v", err)
+  }
 
-	// Verify the public key was stored
-	if oidc.publicKeys["test-key"] == nil {
-		t.Error("Public key was not stored")
-	}
+  // Verify the public key was stored
+  if oidc.publicKeys["test-key"] == nil {
+    t.Error("Public key was not stored")
+  }
 }
 
 // TestIDP is an IDP that we can use for testing.
 // It can produce OIDC signed OIDC tokens that we can use to verify auth is working.
 
 type TestIDP struct {
-	privateKey *rsa.PrivateKey
-	oidc       *OIDC
-	oidcCfg    *config.OIDCConfig
+  privateKey *rsa.PrivateKey
+  oidc       *OIDC
+  oidcCfg    *config.OIDCConfig
 }
 
 func NewTestIDP() (*TestIDP, error) {
-	// Create a test RSA key
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to generate RSA key")
-	}
+  // Create a test RSA key
+  privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to generate RSA key")
+  }
 
-	// Create a test OIDC instance
-	cfg := &config.OIDCConfig{
-		Google: &config.GoogleOIDCConfig{
-			ClientCredentialsFile: "testdata/google-client-dummy.json",
-			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-		},
-		Domains: []string{"example.com"},
-	}
-	oidc, err := newOIDC(cfg)
+  // Create a test OIDC instance
+  cfg := &config.OIDCConfig{
+    Google: &config.GoogleOIDCConfig{
+      ClientCredentialsFile: "testdata/google-client-dummy.json",
+      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+    },
+    Domains: []string{"example.com"},
+  }
+  oidc, err := newOIDC(cfg)
 
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create OIDC instance")
-	}
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create OIDC instance")
+  }
 
-	// Store the public key
-	oidc.publicKeys["test-key"] = &privateKey.PublicKey
+  // Store the public key
+  oidc.publicKeys["test-key"] = &privateKey.PublicKey
 
-	return &TestIDP{
-		privateKey: privateKey,
-		oidc:       oidc,
-		oidcCfg:    cfg,
-	}, nil
+  return &TestIDP{
+    privateKey: privateKey,
+    oidc:       oidc,
+    oidcCfg:    cfg,
+  }, nil
 }
 
 func (idp *TestIDP) GenerateToken(claims jwt.Claims) (string, error) {
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header["kid"] = "test-key"
-	signedToken, err := token.SignedString(idp.privateKey)
-	if err != nil {
-		return "", errors.Wrapf(err, "Failed to sign token")
-	}
+  token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+  token.Header["kid"] = "test-key"
+  signedToken, err := token.SignedString(idp.privateKey)
+  if err != nil {
+    return "", errors.Wrapf(err, "Failed to sign token")
+  }
 
-	return signedToken, nil
+  return signedToken, nil
 }
 
 func TestOIDC_VerifyToken(t *testing.T) {
-	// Create a test RSA key
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("Failed to generate RSA key: %v", err)
-	}
+  idp, err := NewTestIDP()
+  if err != nil {
+    t.Fatalf("Failed to create test IDP: %v", err)
+  }
 
-	// Create a test OIDC instance
-	cfg := &config.OIDCConfig{
-		Google: &config.GoogleOIDCConfig{
-			ClientCredentialsFile: "testdata/google-client-dummy.json",
-			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-		},
-		Domains: []string{"example.com"},
-	}
-	oidc, err := newOIDC(cfg)
-	if err != nil {
-		t.Fatalf("Failed to create OIDC instance: %v", err)
-	}
+  // Create a valid token
+  claims := jwt.MapClaims{
+    "iss": "https://accounts.google.com",
+    "aud": "dummy-client-id",
+    "exp": time.Now().Add(time.Hour).Unix(),
+    "hd":  "example.com",
+  }
 
-	// Store the public key
-	oidc.publicKeys["test-key"] = &privateKey.PublicKey
+  signedToken, err := idp.GenerateToken(claims)
+  if err != nil {
+    t.Fatalf("Failed to sign token: %v", err)
+  }
 
-	// Create a valid token
-	claims := jwt.MapClaims{
-		"iss": "https://accounts.google.com",
-		"aud": "dummy-client-id",
-		"exp": time.Now().Add(time.Hour).Unix(),
-		"hd":  "example.com",
-	}
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header["kid"] = "test-key"
-	signedToken, err := token.SignedString(privateKey)
-	if err != nil {
-		t.Fatalf("Failed to sign token: %v", err)
-	}
+  // Verify the token
+  valid, err := idp.oidc.verifyToken(signedToken)
+  if err != nil {
+    t.Errorf("Unexpected error verifying valid token: %v", err)
+  }
+  if valid == nil {
+    t.Error("Valid token was not accepted")
+  }
 
-	// Verify the token
-	valid, err := oidc.verifyToken(signedToken)
-	if err != nil {
-		t.Errorf("Unexpected error verifying valid token: %v", err)
-	}
-	if valid == nil {
-		t.Error("Valid token was not accepted")
-	}
+  // Test with invalid token
+  valid, err = idp.oidc.verifyToken("invalid-token")
+  if err == nil {
+    t.Error("Expected error with invalid token")
+  }
+  if valid != nil {
+    t.Error("Invalid token was accepted")
+  }
 
-	// Test with invalid token
-	valid, err = oidc.verifyToken("invalid-token")
-	if err == nil {
-		t.Error("Expected error with invalid token")
-	}
-	if valid != nil {
-		t.Error("Invalid token was accepted")
-	}
+  // Test with expired token
+  claims["exp"] = time.Now().Add(-time.Hour).Unix()
+  expiredToken, err := idp.GenerateToken(claims)
+  if err != nil {
+    t.Fatalf("Failed to sign expired token: %v", err)
+  }
 
-	// Test with expired token
-	claims["exp"] = time.Now().Add(-time.Hour).Unix()
-	token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	token.Header["kid"] = "test-key"
-	expiredToken, err := token.SignedString(privateKey)
-	if err != nil {
-		t.Fatalf("Failed to sign expired token: %v", err)
-	}
-
-	valid, err = oidc.verifyToken(expiredToken)
-	if err == nil {
-		t.Error("Expected error with expired token")
-	}
-	if valid != nil {
-		t.Error("Expired token was accepted")
-	}
+  valid, err = idp.oidc.verifyToken(expiredToken)
+  if err == nil {
+    t.Error("Expected error with expired token")
+  }
+  if valid != nil {
+    t.Error("Expired token was accepted")
+  }
 }
 
 func TestOIDCProvider_Google(t *testing.T) {
-	// Create a test Google provider
-	cfg := &config.GoogleOIDCConfig{
-		ClientCredentialsFile: "testdata/google-client-dummy.json",
-		DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-	}
-	provider := NewGoogleProvider(cfg)
+  // Create a test Google provider
+  cfg := &config.GoogleOIDCConfig{
+    ClientCredentialsFile: "testdata/google-client-dummy.json",
+    DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+  }
+  provider := NewGoogleProvider(cfg)
 
-	t.Run("GetOAuth2Config", func(t *testing.T) {
-		config, err := provider.GetOAuth2Config()
-		if err != nil {
-			t.Fatalf("Failed to get OAuth2 config: %v", err)
-		}
-		if config == nil {
-			t.Error("Expected non-nil OAuth2 config")
-		}
-	})
+  t.Run("GetOAuth2Config", func(t *testing.T) {
+    config, err := provider.GetOAuth2Config()
+    if err != nil {
+      t.Fatalf("Failed to get OAuth2 config: %v", err)
+    }
+    if config == nil {
+      t.Error("Expected non-nil OAuth2 config")
+    }
+  })
 
-	t.Run("GetDiscoveryURL", func(t *testing.T) {
-		url := provider.GetDiscoveryURL()
-		if url != cfg.GetDiscoveryURL() {
-			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
-		}
-	})
+  t.Run("GetDiscoveryURL", func(t *testing.T) {
+    url := provider.GetDiscoveryURL()
+    if url != cfg.GetDiscoveryURL() {
+      t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+    }
+  })
 
-	t.Run("ValidateDomainClaims", func(t *testing.T) {
-		// Test valid domain
-		claims := jwt.MapClaims{
-			"hd": "example.com",
-		}
-		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err != nil {
-			t.Errorf("Expected no error for valid domain, got %v", err)
-		}
+  t.Run("ValidateDomainClaims", func(t *testing.T) {
+    // Test valid domain
+    claims := jwt.MapClaims{
+      "hd": "example.com",
+    }
+    err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err != nil {
+      t.Errorf("Expected no error for valid domain, got %v", err)
+    }
 
-		// Test invalid domain
-		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
-		if err == nil {
-			t.Error("Expected error for invalid domain")
-		}
+    // Test invalid domain
+    err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+    if err == nil {
+      t.Error("Expected error for invalid domain")
+    }
 
-		// Test missing hosted domain
-		claims = jwt.MapClaims{}
-		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err == nil {
-			t.Error("Expected error for missing hosted domain")
-		}
+    // Test missing hosted domain
+    claims = jwt.MapClaims{}
+    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err == nil {
+      t.Error("Expected error for missing hosted domain")
+    }
 
-		// Test empty hosted domain
-		claims = jwt.MapClaims{"hd": ""}
-		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err == nil {
-			t.Error("Expected error for empty hosted domain")
-		}
-	})
+    // Test empty hosted domain
+    claims = jwt.MapClaims{"hd": ""}
+    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err == nil {
+      t.Error("Expected error for empty hosted domain")
+    }
+  })
 }
 
 func TestOIDCProvider_Generic(t *testing.T) {
-	// Create a test Generic provider
-	cfg := &config.GenericOIDCConfig{
-		ClientID:     "test-client-id",
-		ClientSecret: "test-client-secret",
-		RedirectURL:  "http://localhost:8080/auth/callback",
-		Scopes:       []string{"openid", "email"},
-		DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
-	}
-	provider := NewGenericProvider(cfg)
+  // Create a test Generic provider
+  cfg := &config.GenericOIDCConfig{
+    ClientID:     "test-client-id",
+    ClientSecret: "test-client-secret",
+    RedirectURL:  "http://localhost:8080/auth/callback",
+    Scopes:       []string{"openid", "email"},
+    DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+  }
+  provider := NewGenericProvider(cfg)
 
-	t.Run("GetOAuth2Config", func(t *testing.T) {
-		config, err := provider.GetOAuth2Config()
-		if err != nil {
-			t.Fatalf("Failed to get OAuth2 config: %v", err)
-		}
-		if config == nil {
-			t.Error("Expected non-nil OAuth2 config")
-		}
-		if config != nil && config.ClientID != cfg.ClientID {
-			t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
-		}
-		if config != nil && config.ClientSecret != cfg.ClientSecret {
-			t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
-		}
-	})
+  t.Run("GetOAuth2Config", func(t *testing.T) {
+    config, err := provider.GetOAuth2Config()
+    if err != nil {
+      t.Fatalf("Failed to get OAuth2 config: %v", err)
+    }
+    if config == nil {
+      t.Error("Expected non-nil OAuth2 config")
+    }
+    if config != nil && config.ClientID != cfg.ClientID {
+      t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
+    }
+    if config != nil && config.ClientSecret != cfg.ClientSecret {
+      t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
+    }
+  })
 
-	t.Run("GetDiscoveryURL", func(t *testing.T) {
-		url := provider.GetDiscoveryURL()
-		if url != cfg.GetDiscoveryURL() {
-			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
-		}
-	})
+  t.Run("GetDiscoveryURL", func(t *testing.T) {
+    url := provider.GetDiscoveryURL()
+    if url != cfg.GetDiscoveryURL() {
+      t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+    }
+  })
 
-	t.Run("ValidateDomainClaims", func(t *testing.T) {
-		// Test valid email domain
-		claims := jwt.MapClaims{
-			"email": "user@example.com",
-		}
-		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err != nil {
-			t.Errorf("Expected no error for valid email domain, got %v", err)
-		}
+  t.Run("ValidateDomainClaims", func(t *testing.T) {
+    // Test valid email domain
+    claims := jwt.MapClaims{
+      "email": "user@example.com",
+    }
+    err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err != nil {
+      t.Errorf("Expected no error for valid email domain, got %v", err)
+    }
 
-		// Test invalid email domain
-		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
-		if err == nil {
-			t.Error("Expected error for invalid email domain")
-		}
+    // Test invalid email domain
+    err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+    if err == nil {
+      t.Error("Expected error for invalid email domain")
+    }
 
-		// Test missing email
-		claims = jwt.MapClaims{}
-		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err == nil {
-			t.Error("Expected error for missing email")
-		}
+    // Test missing email
+    claims = jwt.MapClaims{}
+    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err == nil {
+      t.Error("Expected error for missing email")
+    }
 
-		// Test empty email
-		claims = jwt.MapClaims{"email": ""}
-		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err == nil {
-			t.Error("Expected error for empty email")
-		}
+    // Test empty email
+    claims = jwt.MapClaims{"email": ""}
+    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err == nil {
+      t.Error("Expected error for empty email")
+    }
 
-		// Test invalid email format
-		claims = jwt.MapClaims{"email": "invalid-email"}
-		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-		if err == nil {
-			t.Error("Expected error for invalid email format")
-		}
-	})
+    // Test invalid email format
+    claims = jwt.MapClaims{"email": "invalid-email"}
+    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+    if err == nil {
+      t.Error("Expected error for invalid email format")
+    }
+  })
 }
 
 func TestOIDC_ProviderSelection(t *testing.T) {
-	t.Run("Google Provider", func(t *testing.T) {
-		cfg := &config.OIDCConfig{
-			Google: &config.GoogleOIDCConfig{
-				ClientCredentialsFile: "testdata/google-client-dummy.json",
-				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-			},
-		}
-		oidc, err := newOIDC(cfg)
-		if err != nil {
-			t.Fatalf("Failed to create OIDC instance: %v", err)
-		}
-		if _, ok := oidc.provider.(*GoogleProvider); !ok {
-			t.Error("Expected GoogleProvider, got different provider type")
-		}
-	})
+  t.Run("Google Provider", func(t *testing.T) {
+    cfg := &config.OIDCConfig{
+      Google: &config.GoogleOIDCConfig{
+        ClientCredentialsFile: "testdata/google-client-dummy.json",
+        DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+      },
+    }
+    oidc, err := newOIDC(cfg)
+    if err != nil {
+      t.Fatalf("Failed to create OIDC instance: %v", err)
+    }
+    if _, ok := oidc.provider.(*GoogleProvider); !ok {
+      t.Error("Expected GoogleProvider, got different provider type")
+    }
+  })
 
-	t.Run("Generic Provider", func(t *testing.T) {
-		cfg := &config.OIDCConfig{
-			Generic: &config.GenericOIDCConfig{
-				ClientID:     "test-client-id",
-				ClientSecret: "test-client-secret",
-				RedirectURL:  "http://localhost:8080/auth/callback",
-				Scopes:       []string{"openid", "email"},
-				DiscoveryURL: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
-			},
-		}
-		oidc, err := newOIDC(cfg)
-		if err != nil {
-			t.Fatalf("Failed to create OIDC instance: %v", err)
-		}
-		if _, ok := oidc.provider.(*GenericProvider); !ok {
-			t.Error("Expected GenericProvider, got different provider type")
-		}
-	})
+  t.Run("Generic Provider", func(t *testing.T) {
+    cfg := &config.OIDCConfig{
+      Generic: &config.GenericOIDCConfig{
+        ClientID:     "test-client-id",
+        ClientSecret: "test-client-secret",
+        RedirectURL:  "http://localhost:8080/auth/callback",
+        Scopes:       []string{"openid", "email"},
+        DiscoveryURL: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+      },
+    }
+    oidc, err := newOIDC(cfg)
+    if err != nil {
+      t.Fatalf("Failed to create OIDC instance: %v", err)
+    }
+    if _, ok := oidc.provider.(*GenericProvider); !ok {
+      t.Error("Expected GenericProvider, got different provider type")
+    }
+  })
 
-	t.Run("Both Providers Configured", func(t *testing.T) {
-		cfg := &config.OIDCConfig{
-			Google: &config.GoogleOIDCConfig{
-				ClientCredentialsFile: "testdata/google-client-dummy.json",
-				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-			},
-			Generic: &config.GenericOIDCConfig{
-				ClientID:     "test-client-id",
-				ClientSecret: "test-client-secret",
-				RedirectURL:  "http://localhost:8080/auth/callback",
-				Scopes:       []string{"openid", "email"},
-				DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
-			},
-		}
-		_, err := newOIDC(cfg)
-		if err == nil {
-			t.Error("Expected error when both providers are configured")
-		}
-	})
+  t.Run("Both Providers Configured", func(t *testing.T) {
+    cfg := &config.OIDCConfig{
+      Google: &config.GoogleOIDCConfig{
+        ClientCredentialsFile: "testdata/google-client-dummy.json",
+        DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+      },
+      Generic: &config.GenericOIDCConfig{
+        ClientID:     "test-client-id",
+        ClientSecret: "test-client-secret",
+        RedirectURL:  "http://localhost:8080/auth/callback",
+        Scopes:       []string{"openid", "email"},
+        DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+      },
+    }
+    _, err := newOIDC(cfg)
+    if err == nil {
+      t.Error("Expected error when both providers are configured")
+    }
+  })
 }
 
 type DenyAllChecker struct{}
 
 func (d *DenyAllChecker) Check(principal string, role string) bool {
-	return false
+  return false
 }
 
 func TestOIDC_UnauthenticatedRoutes_NoSession(t *testing.T) {
-	// This test verifies that if there is no session token the user gets back an Unuauthorized error
-	// Create test OIDC config
-	oidcConfig := &config.OIDCConfig{
-		Google: &config.GoogleOIDCConfig{
-			ClientCredentialsFile: "testdata/google-client-dummy.json",
-			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-		},
-	}
+  // This test verifies that if there is no session token the user gets back an Unuauthorized error
+  // Create test OIDC config
+  oidcConfig := &config.OIDCConfig{
+    Google: &config.GoogleOIDCConfig{
+      ClientCredentialsFile: "testdata/google-client-dummy.json",
+      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+    },
+  }
 
-	// Create server config
-	serverConfig := &config.AssistantServerConfig{
-		CorsOrigins: []string{"http://localhost:3000"},
-		OIDC:        oidcConfig,
-	}
+  // Create server config
+  serverConfig := &config.AssistantServerConfig{
+    CorsOrigins: []string{"http://localhost:3000"},
+    OIDC:        oidcConfig,
+  }
 
-	// Create auth mux
-	mux, err := NewAuthMux(serverConfig)
-	if err != nil {
-		t.Fatalf("Failed to create auth mux: %v", err)
-	}
+  // Create auth mux
+  mux, err := NewAuthMux(serverConfig)
+  if err != nil {
+    t.Fatalf("Failed to create auth mux: %v", err)
+  }
 
-	// Register auth routes
-	if err := RegisterAuthRoutes(oidcConfig, mux); err != nil {
-		t.Fatalf("Failed to register auth routes: %v", err)
-	}
+  // Register auth routes
+  if err := RegisterAuthRoutes(oidcConfig, mux); err != nil {
+    t.Fatalf("Failed to register auth routes: %v", err)
+  }
 
-	// Register test routes
-	mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}), &DenyAllChecker{}, "test-role")
+  // Register test routes
+  mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+  }))
+  mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+  }), &DenyAllChecker{}, "test-role")
 
-	// Test public route
-	req := httptest.NewRequest("GET", "/public", nil)
-	rec := httptest.NewRecorder()
-	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusOK {
-		t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
-	}
+  // Test public route
+  req := httptest.NewRequest("GET", "/public", nil)
+  rec := httptest.NewRecorder()
+  mux.ServeHTTP(rec, req)
+  if rec.Code != http.StatusOK {
+    t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
+  }
 
-	// Test protected route
-	req = httptest.NewRequest("GET", "/protected", nil)
-	rec = httptest.NewRecorder()
-	mux.ServeHTTP(rec, req)
+  // Test protected route
+  req = httptest.NewRequest("GET", "/protected", nil)
+  rec = httptest.NewRecorder()
+  mux.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusUnauthorized {
-		t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rec.Code)
-	}
+  if rec.Code != http.StatusUnauthorized {
+    t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rec.Code)
+  }
 
-	msg, err := io.ReadAll(rec.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body: %v", err)
-	}
+  msg, err := io.ReadAll(rec.Body)
+  if err != nil {
+    t.Fatalf("Failed to read response body: %v", err)
+  }
 
-	if string(msg) != "Unauthorized: No valid session\n" {
-		t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
-	}
+  if string(msg) != "Unauthorized: No valid session\n" {
+    t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
+  }
 }
 
-func TestOIDC_UnauthorizedRoutes_Denied(t *testing.T) {
-	// This test verifies that if there is a session token but the user is denied by the IAMPolicy they get
-	// an unauthorized error
-	idp, err := NewTestIDP()
-	if err != nil {
-		t.Fatalf("Failed to create test IDP: %v", err)
-	}
+func TestOIDC_AccessForbidden(t *testing.T) {
+  // This test verifies that if there is a session token but the user is denied by the IAMPolicy they get
+  // a forbidden error
+  idp, err := NewTestIDP()
+  if err != nil {
+    t.Fatalf("Failed to create test IDP: %v", err)
+  }
 
-	// Create server config
-	serverConfig := &config.AssistantServerConfig{
-		CorsOrigins: []string{"http://localhost:3000"},
-		OIDC:        idp.oidcCfg,
-	}
+  // Create server config
+  serverConfig := &config.AssistantServerConfig{
+    CorsOrigins: []string{"http://localhost:3000"},
+    OIDC:        idp.oidcCfg,
+  }
 
-	// Create auth mux
-	mux, err := NewAuthMux(serverConfig)
+  // Create auth mux
+  mux, err := NewAuthMux(serverConfig)
+  if err != nil {
+    t.Fatalf("Failed to create auth mux: %v", err)
+  }
+  // This is a bit of a hack to allow us to inject our test IDP.
+  authMiddleWare, err := newAuthMiddlewareForOIDC(idp.oidc)
+  if err != nil {
+    t.Fatalf("Failed to create auth middleware: %v", err)
+  }
+  mux.authMiddleware = authMiddleWare
+  if err != nil {
+    t.Fatalf("Failed to create auth mux: %v", err)
+  }
 
-	// This is a bit of a hack to allow us to inject our test IDP.
-	authMiddleWare, err := newAuthMiddlewareForOIDC(idp.oidc)
-	if err != nil {
-		t.Fatalf("Failed to create auth middleware: %v", err)
-	}
-	mux.authMiddleware = authMiddleWare
-	if err != nil {
-		t.Fatalf("Failed to create auth mux: %v", err)
-	}
+  // Register auth routes
+  if err := RegisterAuthRoutes(idp.oidcCfg, mux); err != nil {
+    t.Fatalf("Failed to register auth routes: %v", err)
+  }
 
-	// Register auth routes
-	if err := RegisterAuthRoutes(idp.oidcCfg, mux); err != nil {
-		t.Fatalf("Failed to register auth routes: %v", err)
-	}
+  // Register test routes
+  mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+  }))
 
-	// Register test routes
-	mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
+  // We use a DenyAll to make sure we get back unauthorized
+  mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+  }), &DenyAllChecker{}, "test-role")
 
-	// We use a DenyAll to make sure we get back unauthorized
-	mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}), &DenyAllChecker{}, "test-role")
+  signedToken, err := idp.GenerateToken(jwt.MapClaims{
+    "iss":   "https://accounts.google.com",
+    "aud":   "dummy-client-id",
+    "exp":   time.Now().Add(time.Hour).Unix(),
+    "hd":    "example.com",
+    "email": "john@acme.com",
+  })
 
-	signedToken, err := idp.GenerateToken(jwt.MapClaims{
-		"iss":   "https://accounts.google.com",
-		"aud":   "dummy-client-id",
-		"exp":   time.Now().Add(time.Hour).Unix(),
-		"hd":    "example.com",
-		"email": "john@acme.com",
-	})
+  if err != nil {
+    t.Fatalf("Failed to generate token: %v", err)
+  }
 
-	sessionCookie := &http.Cookie{
-		Name:  sessionCookieName,
-		Value: signedToken,
-	}
+  sessionCookie := &http.Cookie{
+    Name:  sessionCookieName,
+    Value: signedToken,
+  }
 
-	// Test protected route
-	req := httptest.NewRequest("GET", "/protected", nil)
-	rec := httptest.NewRecorder()
-	req.AddCookie(sessionCookie)
-	mux.ServeHTTP(rec, req)
-	if rec.Code != http.StatusForbidden {
-		t.Errorf("Expected status code %d, got %d", http.StatusForbidden, rec.Code)
-	}
+  // Test protected route
+  req := httptest.NewRequest("GET", "/protected", nil)
+  rec := httptest.NewRecorder()
+  req.AddCookie(sessionCookie)
+  mux.ServeHTTP(rec, req)
+  if rec.Code != http.StatusForbidden {
+    t.Errorf("Expected status code %d, got %d", http.StatusForbidden, rec.Code)
+  }
 
-	msg, err := io.ReadAll(rec.Body)
-	if err != nil {
-		t.Fatalf("Failed to read response body: %v", err)
-	}
+  msg, err := io.ReadAll(rec.Body)
+  if err != nil {
+    t.Fatalf("Failed to read response body: %v", err)
+  }
 
-	if string(msg) != "Forbidden: user john@acme.com doesn't have role test-role\n" {
-		t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
-	}
+  if string(msg) != "Forbidden: user john@acme.com doesn't have role test-role\n" {
+    t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
+  }
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -302,7 +302,7 @@ func TestOIDC_VerifyToken(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error verifying valid token: %v", err)
 	}
-	if !valid {
+	if valid == nil {
 		t.Error("Valid token was not accepted")
 	}
 
@@ -311,7 +311,7 @@ func TestOIDC_VerifyToken(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error with invalid token")
 	}
-	if valid {
+	if valid != nil {
 		t.Error("Invalid token was accepted")
 	}
 
@@ -328,7 +328,7 @@ func TestOIDC_VerifyToken(t *testing.T) {
 	if err == nil || err.Error() != "hosted domain unknown.com not in allowed domains" {
 		t.Errorf("Expected error 'hosted domain unknown.com not in allowed domains', got: %v", err)
 	}
-	if valid {
+	if valid != nil {
 		t.Error("Invalid token was accepted")
 	}
 
@@ -345,7 +345,7 @@ func TestOIDC_VerifyToken(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error with expired token")
 	}
-	if valid {
+	if valid != nil {
 		t.Error("Expired token was accepted")
 	}
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/pkg/errors"
 	"io"
 	"math/big"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jlewi/cloud-assistant/app/pkg/config"

--- a/app/pkg/server/runner.go
+++ b/app/pkg/server/runner.go
@@ -1,25 +1,26 @@
 package server
 
 import (
-	"github.com/pkg/errors"
-	runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
-	"github.com/runmedev/runme/v3/pkg/command"
-	"github.com/runmedev/runme/v3/pkg/runnerv2service"
-	"go.uber.org/zap"
+  "github.com/pkg/errors"
+  runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
+  "github.com/runmedev/runme/v3/pkg/command"
+  "github.com/runmedev/runme/v3/pkg/runnerv2service"
+  "go.uber.org/zap"
 )
 
 // Runner lets you run commands using Runme.
 type Runner struct {
-	server runnerv2.RunnerServiceServer
+  server runnerv2.RunnerServiceServer
 }
 
 func NewRunner(logger *zap.Logger) (*Runner, error) {
-	factory := command.NewFactory(command.WithLogger(logger))
-	server, err := runnerv2service.NewRunnerService(factory, logger)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed to create Runme runner service")
-	}
-	return &Runner{
-		server: server,
-	}, nil
+  factory := command.NewFactory(command.WithLogger(logger))
+  server, err := runnerv2service.NewRunnerService(factory, logger)
+
+  if err != nil {
+    return nil, errors.Wrapf(err, "Failed to create Runme runner service")
+  }
+  return &Runner{
+    server: server,
+  }, nil
 }

--- a/app/pkg/server/runner.go
+++ b/app/pkg/server/runner.go
@@ -1,26 +1,26 @@
 package server
 
 import (
-  "github.com/pkg/errors"
-  runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
-  "github.com/runmedev/runme/v3/pkg/command"
-  "github.com/runmedev/runme/v3/pkg/runnerv2service"
-  "go.uber.org/zap"
+	"github.com/pkg/errors"
+	runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
+	"github.com/runmedev/runme/v3/pkg/command"
+	"github.com/runmedev/runme/v3/pkg/runnerv2service"
+	"go.uber.org/zap"
 )
 
 // Runner lets you run commands using Runme.
 type Runner struct {
-  server runnerv2.RunnerServiceServer
+	server runnerv2.RunnerServiceServer
 }
 
 func NewRunner(logger *zap.Logger) (*Runner, error) {
-  factory := command.NewFactory(command.WithLogger(logger))
-  server, err := runnerv2service.NewRunnerService(factory, logger)
+	factory := command.NewFactory(command.WithLogger(logger))
+	server, err := runnerv2service.NewRunnerService(factory, logger)
 
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create Runme runner service")
-  }
-  return &Runner{
-    server: server,
-  }, nil
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create Runme runner service")
+	}
+	return &Runner{
+		server: server,
+	}, nil
 }

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -1,279 +1,279 @@
 package server
 
 import (
-  "connectrpc.com/connect"
-  "connectrpc.com/grpchealth"
-  "github.com/jlewi/cloud-assistant/app/api"
-  "github.com/jlewi/cloud-assistant/app/pkg/ai"
-  "github.com/jlewi/cloud-assistant/app/pkg/iam"
-  "github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
-  "golang.org/x/net/http2"
-  "golang.org/x/net/http2/h2c"
+	"connectrpc.com/connect"
+	"connectrpc.com/grpchealth"
+	"github.com/jlewi/cloud-assistant/app/api"
+	"github.com/jlewi/cloud-assistant/app/pkg/ai"
+	"github.com/jlewi/cloud-assistant/app/pkg/iam"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
 
-  "github.com/jlewi/cloud-assistant/app/pkg/logs"
-  "github.com/jlewi/cloud-assistant/app/pkg/tlsbuilder"
+	"github.com/jlewi/cloud-assistant/app/pkg/logs"
+	"github.com/jlewi/cloud-assistant/app/pkg/tlsbuilder"
 
-  "context"
-  "fmt"
+	"context"
+	"fmt"
 
-  "connectrpc.com/otelconnect"
+	"connectrpc.com/otelconnect"
 
-  "github.com/go-logr/zapr"
-  "github.com/jlewi/cloud-assistant/app/pkg/config"
-  "github.com/pkg/errors"
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
+	"github.com/pkg/errors"
 
-  runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
+	runnerv2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
 
-  //"github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2/runnerv2connect"
-  "net"
-  "net/http"
-  "os"
-  "os/signal"
-  "syscall"
-  "time"
+	//"github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2/runnerv2connect"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
-  "go.uber.org/zap"
+	"go.uber.org/zap"
 )
 
 // Server is the main server for the cloud assistant
 type Server struct {
-  telemetry        *config.TelemetryConfig
-  serverConfig     *config.AssistantServerConfig
-  hServer          *http.Server
-  engine           http.Handler
-  shutdownComplete chan bool
-  runner           *Runner
-  agent            *ai.Agent
-  checker          iam.Checker
+	telemetry        *config.TelemetryConfig
+	serverConfig     *config.AssistantServerConfig
+	hServer          *http.Server
+	engine           http.Handler
+	shutdownComplete chan bool
+	runner           *Runner
+	agent            *ai.Agent
+	checker          iam.Checker
 }
 
 type Options struct {
-  Telemetry *config.TelemetryConfig
-  Server    *config.AssistantServerConfig
-  IAMPolicy *api.IAMPolicy
+	Telemetry *config.TelemetryConfig
+	Server    *config.AssistantServerConfig
+	IAMPolicy *api.IAMPolicy
 }
 
 // NewServer creates a new server
 func NewServer(opts Options, agent *ai.Agent) (*Server, error) {
-  log := zapr.NewLogger(zap.L())
-  if agent == nil {
-    if !opts.Server.RunnerService {
-      return nil, errors.New("Agent and Runner service are both disabled")
-    }
-    log.Info("Agent is nil; continuing without AI service")
-  }
+	log := zapr.NewLogger(zap.L())
+	if agent == nil {
+		if !opts.Server.RunnerService {
+			return nil, errors.New("Agent and Runner service are both disabled")
+		}
+		log.Info("Agent is nil; continuing without AI service")
+	}
 
-  var runner *Runner
+	var runner *Runner
 
-  if opts.Server.RunnerService {
-    var err error
-    runner, err = NewRunner(zap.L())
-    if err != nil {
-      return nil, err
-    }
-    ctx := context.Background()
-    session, err := runner.server.CreateSession(ctx, &runnerv2.CreateSessionRequest{
-      Project: &runnerv2.Project{
-        Root:         ".",
-        EnvLoadOrder: []string{".env", ".env.local", ".env.development", ".env.dev"},
-      },
-      Config: &runnerv2.CreateSessionRequest_Config{
-        EnvStoreSeeding: runnerv2.CreateSessionRequest_Config_SESSION_ENV_STORE_SEEDING_SYSTEM.Enum(),
-      },
-    })
-    if err != nil {
-      return nil, err
-    }
-    log.Info("Runner session created", "sessionID", session.GetSession().GetId())
-  } else {
-    log.Info("Runner service is disabled")
-  }
+	if opts.Server.RunnerService {
+		var err error
+		runner, err = NewRunner(zap.L())
+		if err != nil {
+			return nil, err
+		}
+		ctx := context.Background()
+		session, err := runner.server.CreateSession(ctx, &runnerv2.CreateSessionRequest{
+			Project: &runnerv2.Project{
+				Root:         ".",
+				EnvLoadOrder: []string{".env", ".env.local", ".env.development", ".env.dev"},
+			},
+			Config: &runnerv2.CreateSessionRequest_Config{
+				EnvStoreSeeding: runnerv2.CreateSessionRequest_Config_SESSION_ENV_STORE_SEEDING_SYSTEM.Enum(),
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		log.Info("Runner session created", "sessionID", session.GetSession().GetId())
+	} else {
+		log.Info("Runner service is disabled")
+	}
 
-  if opts.Server.OIDC == nil && opts.IAMPolicy != nil {
-    return nil, errors.New("IAM policy is set but OIDC is not configured")
-  }
+	if opts.Server.OIDC == nil && opts.IAMPolicy != nil {
+		return nil, errors.New("IAM policy is set but OIDC is not configured")
+	}
 
-  if opts.Server.OIDC != nil && opts.IAMPolicy == nil {
-    return nil, errors.New("IAM policy must be set if OIDC is configured")
-  }
+	if opts.Server.OIDC != nil && opts.IAMPolicy == nil {
+		return nil, errors.New("IAM policy must be set if OIDC is configured")
+	}
 
-  var checker iam.Checker
+	var checker iam.Checker
 
-  if opts.IAMPolicy != nil {
-    c, err := iam.NewChecker(*opts.IAMPolicy)
-    if err != nil {
-      return nil, errors.Wrapf(err, "Failed to create IAM policy checker")
-    }
-    checker = c
-  } else {
-    checker = &iam.AllowAllChecker{}
-  }
+	if opts.IAMPolicy != nil {
+		c, err := iam.NewChecker(*opts.IAMPolicy)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create IAM policy checker")
+		}
+		checker = c
+	} else {
+		checker = &iam.AllowAllChecker{}
+	}
 
-  s := &Server{
-    telemetry:    opts.Telemetry,
-    serverConfig: opts.Server,
-    runner:       runner,
-    agent:        agent,
-    checker:      checker,
-  }
-  return s, nil
+	s := &Server{
+		telemetry:    opts.Telemetry,
+		serverConfig: opts.Server,
+		runner:       runner,
+		agent:        agent,
+		checker:      checker,
+	}
+	return s, nil
 }
 
 // Run starts the http server
 // Blocks until its shutdown.
 func (s *Server) Run() error {
-  s.shutdownComplete = make(chan bool, 1)
-  trapInterrupt(s)
+	s.shutdownComplete = make(chan bool, 1)
+	trapInterrupt(s)
 
-  logZ := zap.L()
-  log := zapr.NewLogger(logZ)
+	logZ := zap.L()
+	log := zapr.NewLogger(logZ)
 
-  // Register the services
-  if err := s.registerServices(); err != nil {
-    return errors.Wrapf(err, "Failed to register services")
-  }
+	// Register the services
+	if err := s.registerServices(); err != nil {
+		return errors.Wrapf(err, "Failed to register services")
+	}
 
-  serverConfig := s.serverConfig
-  if serverConfig == nil {
-    serverConfig = &config.AssistantServerConfig{}
-  }
+	serverConfig := s.serverConfig
+	if serverConfig == nil {
+		serverConfig = &config.AssistantServerConfig{}
+	}
 
-  port := serverConfig.GetPort()
+	port := serverConfig.GetPort()
 
-  address := fmt.Sprintf("%s:%d", serverConfig.GetBindAddress(), port)
-  log.Info("Starting http server", "address", address)
+	address := fmt.Sprintf("%s:%d", serverConfig.GetBindAddress(), port)
+	log.Info("Starting http server", "address", address)
 
-  // N.B. We don't use an http2 server because we are using websockets and we were having some issues with
-  // http2. Without http2 I'm not sure we can serve grpc.
-  hServer := &http.Server{
-    // Set timeouts to 0 to disable them because we are using websockets
-    WriteTimeout: 0,
-    ReadTimeout:  0,
-    // We need to wrap it in h2c to support HTTP/2 without TLS
-    // TODO(jlewi): Should we only enable h2c if tls isn't enabled?
-    Handler: h2c.NewHandler(s.engine, &http2.Server{}),
-  }
-  // Enable HTTP/2 support
-  if err := http2.ConfigureServer(hServer, &http2.Server{}); err != nil {
-    return errors.Wrapf(err, "failed to configure http2 server")
-  }
+	// N.B. We don't use an http2 server because we are using websockets and we were having some issues with
+	// http2. Without http2 I'm not sure we can serve grpc.
+	hServer := &http.Server{
+		// Set timeouts to 0 to disable them because we are using websockets
+		WriteTimeout: 0,
+		ReadTimeout:  0,
+		// We need to wrap it in h2c to support HTTP/2 without TLS
+		// TODO(jlewi): Should we only enable h2c if tls isn't enabled?
+		Handler: h2c.NewHandler(s.engine, &http2.Server{}),
+	}
+	// Enable HTTP/2 support
+	if err := http2.ConfigureServer(hServer, &http2.Server{}); err != nil {
+		return errors.Wrapf(err, "failed to configure http2 server")
+	}
 
-  s.hServer = hServer
+	s.hServer = hServer
 
-  lis, err := net.Listen("tcp", address)
+	lis, err := net.Listen("tcp", address)
 
-  if err != nil {
-    return errors.Wrapf(err, "Could not start listener")
-  }
+	if err != nil {
+		return errors.Wrapf(err, "Could not start listener")
+	}
 
-  // If TLS is enabled, we need to set up the TLS config
-  if serverConfig.TLSConfig != nil {
-    tlsConfig, err := tlsbuilder.LoadOrGenerateConfig(s.serverConfig.TLSConfig.CertFile, s.serverConfig.TLSConfig.KeyFile, logZ)
-    if err != nil {
-      return err
-    }
-    hServer.TLSConfig = tlsConfig
-  }
+	// If TLS is enabled, we need to set up the TLS config
+	if serverConfig.TLSConfig != nil {
+		tlsConfig, err := tlsbuilder.LoadOrGenerateConfig(s.serverConfig.TLSConfig.CertFile, s.serverConfig.TLSConfig.KeyFile, logZ)
+		if err != nil {
+			return err
+		}
+		hServer.TLSConfig = tlsConfig
+	}
 
-  go func() {
-    // TODO(jlewi): Should we support running TLS and non HTTP on two different ports?
-    if serverConfig.TLSConfig != nil {
-      log.Info("Starting TLS server", "certFile", serverConfig.TLSConfig.CertFile, "keyFile", serverConfig.TLSConfig.KeyFile)
-      // If TLS is enabled, we need to set up the TLS config
-      // We can pass empty strings for the keys here because we have configured TLSConfig
-      if err := hServer.ServeTLS(lis, "", ""); err != nil {
-        if !errors.Is(err, http.ErrServerClosed) {
-          log.Error(err, "There was an error with the http server")
-        }
-      }
-    } else {
-      log.Info("Starting non-TLS server")
-      if err := hServer.Serve(lis); err != nil {
-        if !errors.Is(err, http.ErrServerClosed) {
-          log.Error(err, "There was an error with the http server")
-        }
-      }
-    }
+	go func() {
+		// TODO(jlewi): Should we support running TLS and non HTTP on two different ports?
+		if serverConfig.TLSConfig != nil {
+			log.Info("Starting TLS server", "certFile", serverConfig.TLSConfig.CertFile, "keyFile", serverConfig.TLSConfig.KeyFile)
+			// If TLS is enabled, we need to set up the TLS config
+			// We can pass empty strings for the keys here because we have configured TLSConfig
+			if err := hServer.ServeTLS(lis, "", ""); err != nil {
+				if !errors.Is(err, http.ErrServerClosed) {
+					log.Error(err, "There was an error with the http server")
+				}
+			}
+		} else {
+			log.Info("Starting non-TLS server")
+			if err := hServer.Serve(lis); err != nil {
+				if !errors.Is(err, http.ErrServerClosed) {
+					log.Error(err, "There was an error with the http server")
+				}
+			}
+		}
 
-  }()
+	}()
 
-  // Wait for the shutdown to complete
-  // We use a channel to signal when the shutdown method has completed and then return.
-  // This is necessary because shutdown() is running in a different go function from hServer.Serve. So if we just
-  // relied on hServer.Serve to return and then returned from Run we might still be in the middle of calling shutdown.
-  // That's because shutdown calls hServer.Shutdown which causes hserver.Serve to return.
-  <-s.shutdownComplete
-  return nil
+	// Wait for the shutdown to complete
+	// We use a channel to signal when the shutdown method has completed and then return.
+	// This is necessary because shutdown() is running in a different go function from hServer.Serve. So if we just
+	// relied on hServer.Serve to return and then returned from Run we might still be in the middle of calling shutdown.
+	// That's because shutdown calls hServer.Shutdown which causes hserver.Serve to return.
+	<-s.shutdownComplete
+	return nil
 }
 
 func (s *Server) registerServices() error {
-  log := zapr.NewLogger(zap.L())
+	log := zapr.NewLogger(zap.L())
 
-  // Create auth mux
-  mux, err := NewAuthMux(s.serverConfig)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to create auth mux")
-  }
+	// Create auth mux
+	mux, err := NewAuthMux(s.serverConfig)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create auth mux")
+	}
 
-  // Create the OTEL interceptor
-  otelInterceptor, err := otelconnect.NewInterceptor()
-  if err != nil {
-    return errors.Wrapf(err, "Failed to create otel interceptor")
-  }
+	// Create the OTEL interceptor
+	otelInterceptor, err := otelconnect.NewInterceptor()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create otel interceptor")
+	}
 
-  interceptors := []connect.Interceptor{otelInterceptor}
+	interceptors := []connect.Interceptor{otelInterceptor}
 
-  origins := s.serverConfig.CorsOrigins
-  if len(origins) == 0 {
-    log.Info("No additional CORS origins specified for protected routes")
-  } else {
-    log.Info("Adding CORS support for protected routes", "origins", origins)
-  }
+	origins := s.serverConfig.CorsOrigins
+	if len(origins) == 0 {
+		log.Info("No additional CORS origins specified for protected routes")
+	} else {
+		log.Info("Adding CORS support for protected routes", "origins", origins)
+	}
 
-  // Register auth routes if OIDC is configured
-  if s.serverConfig.OIDC != nil {
-    log.Info("OIDC is configured; registering auth routes")
-    if err := RegisterAuthRoutes(s.serverConfig.OIDC, mux); err != nil {
-      return errors.Wrapf(err, "Failed to register auth routes")
-    }
-  } else {
-    log.Info("OIDC is not configured; auth routes will not be registered")
-  }
+	// Register auth routes if OIDC is configured
+	if s.serverConfig.OIDC != nil {
+		log.Info("OIDC is configured; registering auth routes")
+		if err := RegisterAuthRoutes(s.serverConfig.OIDC, mux); err != nil {
+			return errors.Wrapf(err, "Failed to register auth routes")
+		}
+	} else {
+		log.Info("OIDC is not configured; auth routes will not be registered")
+	}
 
-  if s.agent != nil {
-    aiSvcPath, aiSvcHandler := cassieconnect.NewBlocksServiceHandler(s.agent, connect.WithInterceptors(interceptors...))
-    log.Info("Setting up AI service", "path", aiSvcPath)
-    // Protect the AI service
-    mux.HandleProtected(aiSvcPath, aiSvcHandler, s.checker, api.AgentUserRole)
-  } else {
-    log.Info("Agent is nil; AI service is disabled")
-  }
+	if s.agent != nil {
+		aiSvcPath, aiSvcHandler := cassieconnect.NewBlocksServiceHandler(s.agent, connect.WithInterceptors(interceptors...))
+		log.Info("Setting up AI service", "path", aiSvcPath)
+		// Protect the AI service
+		mux.HandleProtected(aiSvcPath, aiSvcHandler, s.checker, api.AgentUserRole)
+	} else {
+		log.Info("Agent is nil; AI service is disabled")
+	}
 
-  if s.runner != nil {
-    sHandler := &WebSocketHandler{
-      runner: s.runner,
-    }
-    // Protect the WebSocket handler
-    mux.HandleProtected("/ws", http.HandlerFunc(sHandler.Handler), s.checker, api.RunnerUserRole)
-    log.Info("Setting up runner service", "path", "/ws")
-  }
+	if s.runner != nil {
+		sHandler := &WebSocketHandler{
+			runner: s.runner,
+		}
+		// Protect the WebSocket handler
+		mux.HandleProtected("/ws", http.HandlerFunc(sHandler.Handler), s.checker, api.RunnerUserRole)
+		log.Info("Setting up runner service", "path", "/ws")
+	}
 
-  // Health check should be public
-  checker := grpchealth.NewStaticChecker()
-  mux.Handle(grpchealth.NewHandler(checker))
+	// Health check should be public
+	checker := grpchealth.NewStaticChecker()
+	mux.Handle(grpchealth.NewHandler(checker))
 
-  mux.HandleFunc("/trailerstest", trailersTest)
+	mux.HandleFunc("/trailerstest", trailersTest)
 
-  // Handle the single page app and assets unprotected
-  singlePageApp, err := s.singlePageAppHandler()
-  if err != nil {
-    return errors.Wrapf(err, "Failed to serve single page app")
-  }
-  mux.Handle("/", singlePageApp)
+	// Handle the single page app and assets unprotected
+	singlePageApp, err := s.singlePageAppHandler()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to serve single page app")
+	}
+	mux.Handle("/", singlePageApp)
 
-  s.engine = mux
+	s.engine = mux
 
-  return nil
+	return nil
 }
 
 // trailersTest is a function to test returning trailers.
@@ -283,50 +283,50 @@ func (s *Server) registerServices() error {
 // curl -k -v --http2 https://cloud-assistant.gateway.unified-0s.internal.api.openai.org/trailerstest -d ”
 // The output should show the trailers in the response headers.
 func trailersTest(w http.ResponseWriter, r *http.Request) {
-  w.Header().Set("Content-Type", "application/grpc+proto")
-  w.Header().Set("Trailer", "Grpc-Status, Grpc-Message")
+	w.Header().Set("Content-Type", "application/grpc+proto")
+	w.Header().Set("Trailer", "Grpc-Status, Grpc-Message")
 
-  w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusOK)
 
-  log := logs.FromContext(r.Context())
-  // Write response body
-  if _, err := w.Write([]byte("... this is the response ...")); err != nil {
-    log.Error(err, "Failed to write response body")
-  }
+	log := logs.FromContext(r.Context())
+	// Write response body
+	if _, err := w.Write([]byte("... this is the response ...")); err != nil {
+		log.Error(err, "Failed to write response body")
+	}
 
-  // Now set trailers
-  w.Header().Set("Grpc-Status", "0")
-  w.Header().Set("Grpc-Message", "OK")
+	// Now set trailers
+	w.Header().Set("Grpc-Status", "0")
+	w.Header().Set("Grpc-Message", "OK")
 }
 
 func (s *Server) shutdown() {
-  log := zapr.NewLogger(zap.L())
-  log.Info("Shutting down the cloud-assistant server")
+	log := zapr.NewLogger(zap.L())
+	log.Info("Shutting down the cloud-assistant server")
 
-  if s.hServer != nil {
-    ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-    defer cancel()
-    if err := s.hServer.Shutdown(ctx); err != nil {
-      log.Error(err, "Error shutting down http server")
-    }
-    log.Info("HTTP Server shutdown complete")
-  }
-  log.Info("Shutdown complete")
-  s.shutdownComplete <- true
+	if s.hServer != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		if err := s.hServer.Shutdown(ctx); err != nil {
+			log.Error(err, "Error shutting down http server")
+		}
+		log.Info("HTTP Server shutdown complete")
+	}
+	log.Info("Shutdown complete")
+	s.shutdownComplete <- true
 }
 
 // trapInterrupt shutdowns the server if the appropriate signals are sent
 func trapInterrupt(s *Server) {
-  log := zapr.NewLogger(zap.L())
-  sigs := make(chan os.Signal, 10)
-  // Note SIGSTOP and SIGTERM can't be caught
-  // We can trap SIGINT which is what ctl-z sends to interrupt the process
-  // to interrupt the process
-  signal.Notify(sigs, syscall.SIGINT)
+	log := zapr.NewLogger(zap.L())
+	sigs := make(chan os.Signal, 10)
+	// Note SIGSTOP and SIGTERM can't be caught
+	// We can trap SIGINT which is what ctl-z sends to interrupt the process
+	// to interrupt the process
+	signal.Notify(sigs, syscall.SIGINT)
 
-  go func() {
-    msg := <-sigs
-    log.Info("Received signal", "signal", msg)
-    s.shutdown()
-  }()
+	go func() {
+		msg := <-sigs
+		log.Info("Received signal", "signal", msg)
+		s.shutdown()
+	}()
 }

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -176,9 +176,12 @@ func (s *Server) registerServices() error {
 
 	// Register auth routes if OIDC is configured
 	if s.serverConfig.OIDC != nil {
+		log.Info("OIDC is configured; registering auth routes")
 		if err := RegisterAuthRoutes(s.serverConfig.OIDC, mux); err != nil {
 			return errors.Wrapf(err, "Failed to register auth routes")
 		}
+	} else {
+		log.Info("OIDC is not configured; auth routes will not be registered")
 	}
 
 	if s.agent != nil {

--- a/app/pkg/server/server_test.go
+++ b/app/pkg/server/server_test.go
@@ -1,637 +1,637 @@
 package server
 
 import (
-  "context"
-  "crypto/tls"
-  "fmt"
-  "net"
-  "net/http"
-  "net/url"
-  "os"
-  "os/signal"
-  "testing"
-  "time"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/signal"
+	"testing"
+	"time"
 
-  "connectrpc.com/connect"
-  "github.com/go-logr/zapr"
-  "github.com/google/uuid"
-  "github.com/gorilla/websocket"
-  "github.com/jlewi/cloud-assistant/app/pkg/ai"
-  "github.com/jlewi/cloud-assistant/app/pkg/application"
-  "github.com/jlewi/cloud-assistant/app/pkg/config"
-  "github.com/jlewi/cloud-assistant/app/pkg/logs"
-  "github.com/jlewi/cloud-assistant/protos/gen/cassie"
-  "github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
-  "github.com/jlewi/monogo/networking"
-  "github.com/pkg/errors"
-  v2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
-  "go.uber.org/zap"
-  "golang.org/x/net/http2"
-  "google.golang.org/grpc/health/grpc_health_v1"
-  "google.golang.org/protobuf/encoding/protojson"
+	"connectrpc.com/connect"
+	"github.com/go-logr/zapr"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/jlewi/cloud-assistant/app/pkg/ai"
+	"github.com/jlewi/cloud-assistant/app/pkg/application"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
+	"github.com/jlewi/cloud-assistant/app/pkg/logs"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
+	"github.com/jlewi/monogo/networking"
+	"github.com/pkg/errors"
+	v2 "github.com/runmedev/runme/v3/pkg/api/gen/proto/go/runme/runner/v2"
+	"go.uber.org/zap"
+	"golang.org/x/net/http2"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func Test_HealthCheck(t *testing.T) {
-  // Try sending a healthcheck to the given server.
-  // This is solely for the purpose of trying to reproduce the grpc-trailer issue
-  SkipIfMissing(t, "RUN_MANUAL_TESTS")
-  app := application.NewApp()
-  err := app.LoadConfig(nil)
-  if err != nil {
-    t.Fatalf("Error loading config; %v", err)
-  }
+	// Try sending a healthcheck to the given server.
+	// This is solely for the purpose of trying to reproduce the grpc-trailer issue
+	SkipIfMissing(t, "RUN_MANUAL_TESTS")
+	app := application.NewApp()
+	err := app.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("Error loading config; %v", err)
+	}
 
-  if err := app.SetupLogging(); err != nil {
-    t.Fatalf("Error setting up logging; %v", err)
-  }
-  addr := "https://localhost:9080"
-  if err := waitForServer(addr); err != nil {
-    t.Fatalf("Error waiting for server; %v", err)
-  }
-  t.Logf("Server started")
+	if err := app.SetupLogging(); err != nil {
+		t.Fatalf("Error setting up logging; %v", err)
+	}
+	addr := "https://localhost:9080"
+	if err := waitForServer(addr); err != nil {
+		t.Fatalf("Error waiting for server; %v", err)
+	}
+	t.Logf("Server started")
 }
 
 func Test_GenerateBlocks(t *testing.T) {
-  SkipIfMissing(t, "RUN_MANUAL_TESTS")
+	SkipIfMissing(t, "RUN_MANUAL_TESTS")
 
-  app := application.NewApp()
-  err := app.LoadConfig(nil)
-  if err != nil {
-    t.Fatalf("Error loading config; %v", err)
-  }
-  cfg := app.GetConfig()
+	app := application.NewApp()
+	err := app.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("Error loading config; %v", err)
+	}
+	cfg := app.GetConfig()
 
-  if err := app.SetupLogging(); err != nil {
-    t.Fatalf("Error setting up logging; %v", err)
-  }
+	if err := app.SetupLogging(); err != nil {
+		t.Fatalf("Error setting up logging; %v", err)
+	}
 
-  log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
+	log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
 
-  port, err := networking.GetFreePort()
-  if err != nil {
-    t.Fatalf("Error getting free port; %v", err)
-  }
+	port, err := networking.GetFreePort()
+	if err != nil {
+		t.Fatalf("Error getting free port; %v", err)
+	}
 
-  if cfg.AssistantServer == nil {
-    cfg.AssistantServer = &config.AssistantServerConfig{}
-  }
-  cfg.AssistantServer.Port = port
-  addr := fmt.Sprintf("https://localhost:%v", cfg.AssistantServer.Port)
+	if cfg.AssistantServer == nil {
+		cfg.AssistantServer = &config.AssistantServerConfig{}
+	}
+	cfg.AssistantServer.Port = port
+	addr := fmt.Sprintf("https://localhost:%v", cfg.AssistantServer.Port)
 
-  go func() {
-    if err := setupAndRunServer(*cfg); err != nil {
-      log.Error(err, "Error running server")
-    }
-  }()
+	go func() {
+		if err := setupAndRunServer(*cfg); err != nil {
+			log.Error(err, "Error running server")
+		}
+	}()
 
-  // N.B. There's probably a race condition here because the client might start before the server is fully up.
-  // Or maybe that's implicitly handled because the connection won't succeed until the server is up?
-  if err := waitForServer(addr); err != nil {
-    t.Fatalf("Error waiting for server; %v", err)
-  }
+	// N.B. There's probably a race condition here because the client might start before the server is fully up.
+	// Or maybe that's implicitly handled because the connection won't succeed until the server is up?
+	if err := waitForServer(addr); err != nil {
+		t.Fatalf("Error waiting for server; %v", err)
+	}
 
-  log.Info("Server started")
-  blocks, err := runAIClient(addr)
+	log.Info("Server started")
+	blocks, err := runAIClient(addr)
 
-  if err != nil {
-    t.Fatalf("Error running client for addres %v; %v", addr, err)
-  }
+	if err != nil {
+		t.Fatalf("Error running client for addres %v; %v", addr, err)
+	}
 
-  if len(blocks) < 2 {
-    t.Errorf("Expected at least 2 blocks; got %d blocks", len(blocks))
-  }
+	if len(blocks) < 2 {
+		t.Errorf("Expected at least 2 blocks; got %d blocks", len(blocks))
+	}
 
-  // Ensure there is a filesearch results block and that the filenames are set. This is intended
-  // to catch various bugs with the SDK; e.g.
-  // https://openai.slack.com/archives/C05C3578WQZ/p1741520938xxxxx5?thread_ts=1741090029.923169&cid=C05C3578WQZ
-  hasFSBlock := false
-  for _, b := range blocks {
-    if b.Kind == cassie.BlockKind_FILE_SEARCH_RESULTS {
-      hasFSBlock = true
+	// Ensure there is a filesearch results block and that the filenames are set. This is intended
+	// to catch various bugs with the SDK; e.g.
+	// https://openai.slack.com/archives/C05C3578WQZ/p1741520938xxxxx5?thread_ts=1741090029.923169&cid=C05C3578WQZ
+	hasFSBlock := false
+	for _, b := range blocks {
+		if b.Kind == cassie.BlockKind_FILE_SEARCH_RESULTS {
+			hasFSBlock = true
 
-      if len(b.FileSearchResults) <= 0 {
-        t.Errorf("FileSearchResults block has no results")
-      }
+			if len(b.FileSearchResults) <= 0 {
+				t.Errorf("FileSearchResults block has no results")
+			}
 
-      for _, r := range b.FileSearchResults {
-        if r.FileName == "" {
-          t.Errorf("FileSearchResults block has empty filename")
-        }
-      }
-    }
-  }
+			for _, r := range b.FileSearchResults {
+				if r.FileName == "" {
+					t.Errorf("FileSearchResults block has empty filename")
+				}
+			}
+		}
+	}
 
-  if !hasFSBlock {
-    t.Errorf("There was no FileSearch block in the results.")
-  }
+	if !hasFSBlock {
+		t.Errorf("There was no FileSearch block in the results.")
+	}
 
 }
 
 func runAIClient(baseURL string) (map[string]*cassie.Block, error) {
-  log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
+	log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
 
-  blocks := make(map[string]*cassie.Block)
+	blocks := make(map[string]*cassie.Block)
 
-  Block := cassie.Block{
-    Kind:     cassie.BlockKind_MARKUP,
-    Contents: "This is a block",
-  }
+	Block := cassie.Block{
+		Kind:     cassie.BlockKind_MARKUP,
+		Contents: "This is a block",
+	}
 
-  log.Info("Block", logs.ZapProto("block", &Block))
+	log.Info("Block", logs.ZapProto("block", &Block))
 
-  u, err := url.Parse(baseURL)
-  if err != nil {
-    log.Error(err, "Failed to parse URL")
-    return blocks, errors.Wrapf(err, "Failed to parse URL")
-  }
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		log.Error(err, "Failed to parse URL")
+		return blocks, errors.Wrapf(err, "Failed to parse URL")
+	}
 
-  var client cassieconnect.BlocksServiceClient
+	var client cassieconnect.BlocksServiceClient
 
-  // Mimic what the frontend does
-  options := []connect.ClientOption{connect.WithGRPCWeb()}
-  if u.Scheme == "https" {
-    // Configure the TLS settings
-    tlsConfig := &tls.Config{
-      InsecureSkipVerify: true, // Set to true only for testing; otherwise validate the server's certificate
-    }
+	// Mimic what the frontend does
+	options := []connect.ClientOption{connect.WithGRPCWeb()}
+	if u.Scheme == "https" {
+		// Configure the TLS settings
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true, // Set to true only for testing; otherwise validate the server's certificate
+		}
 
-    client = cassieconnect.NewBlocksServiceClient(
-      &http.Client{
-        Transport: &http2.Transport{
-          TLSClientConfig: tlsConfig,
-          DialTLSContext: func(ctx context.Context, network, addr string, config *tls.Config) (net.Conn, error) {
-            // Create a secure connection with TLS
-            return tls.Dial(network, addr, config)
-          },
-        },
-      },
-      baseURL,
-      options...,
-    )
-  } else {
-    client = cassieconnect.NewBlocksServiceClient(
-      &http.Client{
-        Transport: &http2.Transport{
-          AllowHTTP: true,
-          DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-            // Use the standard Dial function to create a plain TCP connection
-            return net.Dial(network, u.Host)
-          },
-        },
-      },
-      baseURL,
-      options...,
-    )
-  }
+		client = cassieconnect.NewBlocksServiceClient(
+			&http.Client{
+				Transport: &http2.Transport{
+					TLSClientConfig: tlsConfig,
+					DialTLSContext: func(ctx context.Context, network, addr string, config *tls.Config) (net.Conn, error) {
+						// Create a secure connection with TLS
+						return tls.Dial(network, addr, config)
+					},
+				},
+			},
+			baseURL,
+			options...,
+		)
+	} else {
+		client = cassieconnect.NewBlocksServiceClient(
+			&http.Client{
+				Transport: &http2.Transport{
+					AllowHTTP: true,
+					DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+						// Use the standard Dial function to create a plain TCP connection
+						return net.Dial(network, u.Host)
+					},
+				},
+			},
+			baseURL,
+			options...,
+		)
+	}
 
-  ctx := context.Background()
-  genReq := &cassie.GenerateRequest{
-    Blocks: []*cassie.Block{
-      {
-        Kind:     cassie.BlockKind_MARKUP,
-        Role:     cassie.BlockRole_BLOCK_ROLE_USER,
-        Contents: "Show me all the AKS clusters at OpenAI",
-      },
-    },
-  }
-  req := connect.NewRequest(genReq)
+	ctx := context.Background()
+	genReq := &cassie.GenerateRequest{
+		Blocks: []*cassie.Block{
+			{
+				Kind:     cassie.BlockKind_MARKUP,
+				Role:     cassie.BlockRole_BLOCK_ROLE_USER,
+				Contents: "Show me all the AKS clusters at OpenAI",
+			},
+		},
+	}
+	req := connect.NewRequest(genReq)
 
-  stream, err := client.Generate(ctx, req)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to create generate stream")
-  }
+	stream, err := client.Generate(ctx, req)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to create generate stream")
+	}
 
-  // Receive responses
-  for stream.Receive() {
-    response := stream.Msg()
+	// Receive responses
+	for stream.Receive() {
+		response := stream.Msg()
 
-    for _, block := range response.Blocks {
-      blocks[block.Id] = block
+		for _, block := range response.Blocks {
+			blocks[block.Id] = block
 
-      options := protojson.MarshalOptions{
-        Multiline: true,
-        Indent:    "  ", // Two spaces for indentation
-      }
+			options := protojson.MarshalOptions{
+				Multiline: true,
+				Indent:    "  ", // Two spaces for indentation
+			}
 
-      // Marshal the protobuf message to JSON
-      jsonData, err := options.Marshal(block)
-      if err != nil {
-        log.Error(err, "Failed to marshal block to JSON")
-      } else {
-        log.Info("Block", "block", string(jsonData))
-      }
-    }
+			// Marshal the protobuf message to JSON
+			jsonData, err := options.Marshal(block)
+			if err != nil {
+				log.Error(err, "Failed to marshal block to JSON")
+			} else {
+				log.Info("Block", "block", string(jsonData))
+			}
+		}
 
-  }
+	}
 
-  if stream.Err() != nil {
-    return blocks, errors.Wrapf(stream.Err(), "Error receiving response")
-  }
-  return blocks, nil
+	if stream.Err() != nil {
+		return blocks, errors.Wrapf(stream.Err(), "Error receiving response")
+	}
+	return blocks, nil
 }
 
 func Test_ExecuteWithRunme(t *testing.T) {
-  SkipIfMissing(t, "RUN_MANUAL_TESTS")
+	SkipIfMissing(t, "RUN_MANUAL_TESTS")
 
-  app := application.NewApp()
-  err := app.LoadConfig(nil)
-  if err != nil {
-    t.Fatalf("Error loading config; %v", err)
-  }
-  cfg := app.Config
+	app := application.NewApp()
+	err := app.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("Error loading config; %v", err)
+	}
+	cfg := app.Config
 
-  if err := app.SetupLogging(); err != nil {
-    t.Fatalf("Error setting up logging; %v", err)
-  }
+	if err := app.SetupLogging(); err != nil {
+		t.Fatalf("Error setting up logging; %v", err)
+	}
 
-  log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
+	log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
 
-  port, err := networking.GetFreePort()
-  if err != nil {
-    t.Fatalf("Error getting free port; %v", err)
-  }
+	port, err := networking.GetFreePort()
+	if err != nil {
+		t.Fatalf("Error getting free port; %v", err)
+	}
 
-  if cfg.AssistantServer == nil {
-    cfg.AssistantServer = &config.AssistantServerConfig{}
-  }
-  cfg.AssistantServer.Port = port
-  // N.B. Server currently needs to be started manually. Should we start it autommatically?
-  addr := fmt.Sprintf("http://localhost:%v", cfg.AssistantServer.Port)
-  go func() {
-    if err := setupAndRunServer(*cfg); err != nil {
-      log.Error(err, "Error running server")
-    }
-  }()
+	if cfg.AssistantServer == nil {
+		cfg.AssistantServer = &config.AssistantServerConfig{}
+	}
+	cfg.AssistantServer.Port = port
+	// N.B. Server currently needs to be started manually. Should we start it autommatically?
+	addr := fmt.Sprintf("http://localhost:%v", cfg.AssistantServer.Port)
+	go func() {
+		if err := setupAndRunServer(*cfg); err != nil {
+			log.Error(err, "Error running server")
+		}
+	}()
 
-  // N.B. There's probably a race condition here because the client might start before the server is fully up.
-  // Or maybe that's implicitly handled because the connection won't succeed until the server is up?
-  if err := waitForServer(addr); err != nil {
-    t.Fatalf("Error waiting for server; %v", err)
-  }
+	// N.B. There's probably a race condition here because the client might start before the server is fully up.
+	// Or maybe that's implicitly handled because the connection won't succeed until the server is up?
+	if err := waitForServer(addr); err != nil {
+		t.Fatalf("Error waiting for server; %v", err)
+	}
 
-  log.Info("Server started")
-  _, err = runRunmeClient(addr)
+	log.Info("Server started")
+	_, err = runRunmeClient(addr)
 
-  if err != nil {
-    t.Fatalf("Error running client for addres %v; %v", addr, err)
-  }
+	if err != nil {
+		t.Fatalf("Error running client for addres %v; %v", addr, err)
+	}
 
 }
 
 func Test_ExecuteWithRunmeConcurrent(t *testing.T) {
-  // The purpose of this test test is to verify that if we use to ExecuteRequests without waiting for the first to
-  // finish that the server can handle this. Specifically, we want to make sure we don't have concurrent writes
-  // to the websocket on the backend because that causes a panic
-  SkipIfMissing(t, "RUN_MANUAL_TESTS")
+	// The purpose of this test test is to verify that if we use to ExecuteRequests without waiting for the first to
+	// finish that the server can handle this. Specifically, we want to make sure we don't have concurrent writes
+	// to the websocket on the backend because that causes a panic
+	SkipIfMissing(t, "RUN_MANUAL_TESTS")
 
-  app := application.NewApp()
-  err := app.LoadConfig(nil)
-  if err != nil {
-    t.Fatalf("Error loading config; %v", err)
-  }
-  cfg := app.Config
+	app := application.NewApp()
+	err := app.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("Error loading config; %v", err)
+	}
+	cfg := app.Config
 
-  if err := app.SetupLogging(); err != nil {
-    t.Fatalf("Error setting up logging; %v", err)
-  }
+	if err := app.SetupLogging(); err != nil {
+		t.Fatalf("Error setting up logging; %v", err)
+	}
 
-  log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
+	log := zapr.NewLoggerWithOptions(zap.L(), zapr.AllowZapFields(true))
 
-  port, err := networking.GetFreePort()
-  if err != nil {
-    t.Fatalf("Error getting free port; %v", err)
-  }
+	port, err := networking.GetFreePort()
+	if err != nil {
+		t.Fatalf("Error getting free port; %v", err)
+	}
 
-  if cfg.AssistantServer == nil {
-    cfg.AssistantServer = &config.AssistantServerConfig{}
-  }
-  cfg.AssistantServer.Port = port
-  // N.B. Server currently needs to be started manually. Should we start it autommatically?
-  addr := fmt.Sprintf("http://localhost:%v", cfg.AssistantServer.Port)
-  go func() {
-    if err := setupAndRunServer(*cfg); err != nil {
-      log.Error(err, "Error running server")
-    }
-  }()
+	if cfg.AssistantServer == nil {
+		cfg.AssistantServer = &config.AssistantServerConfig{}
+	}
+	cfg.AssistantServer.Port = port
+	// N.B. Server currently needs to be started manually. Should we start it autommatically?
+	addr := fmt.Sprintf("http://localhost:%v", cfg.AssistantServer.Port)
+	go func() {
+		if err := setupAndRunServer(*cfg); err != nil {
+			log.Error(err, "Error running server")
+		}
+	}()
 
-  // N.B. There's probably a race condition here because the client might start before the server is fully up.
-  // Or maybe that's implicitly handled because the connection won't succeed until the server is up?
-  if err := waitForServer(addr); err != nil {
-    t.Fatalf("Error waiting for server; %v", err)
-  }
+	// N.B. There's probably a race condition here because the client might start before the server is fully up.
+	// Or maybe that's implicitly handled because the connection won't succeed until the server is up?
+	if err := waitForServer(addr); err != nil {
+		t.Fatalf("Error waiting for server; %v", err)
+	}
 
-  log.Info("Server started")
-  _, err = runRunmeClientConcurrent(addr)
+	log.Info("Server started")
+	_, err = runRunmeClientConcurrent(addr)
 
-  if err != nil {
-    t.Fatalf("Error running client for addres %v; %v", addr, err)
-  }
+	if err != nil {
+		t.Fatalf("Error running client for addres %v; %v", addr, err)
+	}
 
 }
 
 func setupAndRunServer(cfg config.Config) error {
-  log := zapr.NewLogger(zap.L())
+	log := zapr.NewLogger(zap.L())
 
-  client, err := ai.NewClient(*cfg.OpenAI)
+	client, err := ai.NewClient(*cfg.OpenAI)
 
-  if err != nil {
-    return errors.Wrap(err, "Failed to create client")
-  }
+	if err != nil {
+		return errors.Wrap(err, "Failed to create client")
+	}
 
-  agentOptions := &ai.AgentOptions{}
+	agentOptions := &ai.AgentOptions{}
 
-  if err := agentOptions.FromAssistantConfig(*cfg.CloudAssistant); err != nil {
-    return err
-  }
+	if err := agentOptions.FromAssistantConfig(*cfg.CloudAssistant); err != nil {
+		return err
+	}
 
-  agentOptions.Client = client
+	agentOptions.Client = client
 
-  agent, err := ai.NewAgent(*agentOptions)
+	agent, err := ai.NewAgent(*agentOptions)
 
-  if err != nil {
-    return err
-  }
+	if err != nil {
+		return err
+	}
 
-  serverOptions := &Options{
-    Telemetry: cfg.Telemetry,
-    Server:    cfg.AssistantServer,
-  }
-  srv, err := NewServer(*serverOptions, agent)
+	serverOptions := &Options{
+		Telemetry: cfg.Telemetry,
+		Server:    cfg.AssistantServer,
+	}
+	srv, err := NewServer(*serverOptions, agent)
 
-  if err != nil {
-    return errors.Wrap(err, "Failed to create server")
-  }
-  go func() {
-    if err := srv.Run(); err != nil {
-      log.Error(err, "Error running server")
-    }
-    log.Info("Shutting down server...")
-    srv.shutdown()
-  }()
-  log.Info("Server stopped")
-  return nil
+	if err != nil {
+		return errors.Wrap(err, "Failed to create server")
+	}
+	go func() {
+		if err := srv.Run(); err != nil {
+			log.Error(err, "Error running server")
+		}
+		log.Info("Shutting down server...")
+		srv.shutdown()
+	}()
+	log.Info("Server stopped")
+	return nil
 }
 
 func waitForServer(addr string) error {
-  log := zapr.NewLogger(zap.L())
-  log.Info("Waiting for server to start", "address", addr)
-  endTime := time.Now().Add(30 * time.Second)
-  wait := 2 * time.Second
-  for time.Now().Before(endTime) {
+	log := zapr.NewLogger(zap.L())
+	log.Info("Waiting for server to start", "address", addr)
+	endTime := time.Now().Add(30 * time.Second)
+	wait := 2 * time.Second
+	for time.Now().Before(endTime) {
 
-    // 1. Create a custom transport that skips TLS verification
-    // Important we need to use http2.Transport to support HTTP/2 and properly handle trailers with gRPCWeb
-    customTransport := &http2.Transport{
-      TLSClientConfig: &tls.Config{
-        InsecureSkipVerify: true, // ⚠️ Accept ANY cert (dangerous in production!)
+		// 1. Create a custom transport that skips TLS verification
+		// Important we need to use http2.Transport to support HTTP/2 and properly handle trailers with gRPCWeb
+		customTransport := &http2.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // ⚠️ Accept ANY cert (dangerous in production!)
 
-      },
-      DialTLSContext: func(ctx context.Context, network, addr string, config *tls.Config) (net.Conn, error) {
-        // Create a secure connection with TLS
-        return tls.Dial(network, addr, config)
-      },
-    }
+			},
+			DialTLSContext: func(ctx context.Context, network, addr string, config *tls.Config) (net.Conn, error) {
+				// Create a secure connection with TLS
+				return tls.Dial(network, addr, config)
+			},
+		}
 
-    // 2. Create an HTTP client using the custom transport
-    customHTTPClient := &http.Client{
-      Timeout:   10 * time.Second,
-      Transport: customTransport,
-    }
+		// 2. Create an HTTP client using the custom transport
+		customHTTPClient := &http.Client{
+			Timeout:   10 * time.Second,
+			Transport: customTransport,
+		}
 
-    client := connect.NewClient[grpc_health_v1.HealthCheckRequest, grpc_health_v1.HealthCheckResponse](
-      customHTTPClient,
-      //http.DefaultClient,
-      addr+"/grpc.health.v1.Health/Check", // Adjust if using a different route
-      // N.B. We use GRPCWeb to mimic what the frontend does. The frontend will use GRPCWeb to support streaming.
-      connect.WithGRPCWeb(),
-    )
+		client := connect.NewClient[grpc_health_v1.HealthCheckRequest, grpc_health_v1.HealthCheckResponse](
+			customHTTPClient,
+			//http.DefaultClient,
+			addr+"/grpc.health.v1.Health/Check", // Adjust if using a different route
+			// N.B. We use GRPCWeb to mimic what the frontend does. The frontend will use GRPCWeb to support streaming.
+			connect.WithGRPCWeb(),
+		)
 
-    resp, err := client.CallUnary(context.Background(), connect.NewRequest(&grpc_health_v1.HealthCheckRequest{}))
+		resp, err := client.CallUnary(context.Background(), connect.NewRequest(&grpc_health_v1.HealthCheckRequest{}))
 
-    if err != nil {
-      time.Sleep(wait)
-      continue
-    }
+		if err != nil {
+			time.Sleep(wait)
+			continue
+		}
 
-    if resp.Msg.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
-      return nil
-    } else {
-      log.Info("Server not ready", "status", resp.Msg.GetStatus())
-    }
-  }
-  return errors.Errorf("Server didn't start in time")
+		if resp.Msg.GetStatus() == grpc_health_v1.HealthCheckResponse_SERVING {
+			return nil
+		} else {
+			log.Info("Server not ready", "status", resp.Msg.GetStatus())
+		}
+	}
+	return errors.Errorf("Server didn't start in time")
 }
 
 func runRunmeClient(baseURL string) (map[string]any, error) {
-  interrupt := make(chan os.Signal, 1)
-  signal.Notify(interrupt, os.Interrupt)
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
 
-  log := logs.NewLogger()
+	log := logs.NewLogger()
 
-  blocks := make(map[string]any)
+	blocks := make(map[string]any)
 
-  base, err := url.Parse(baseURL)
-  if err != nil {
-    log.Error(err, "Failed to parse URL")
-    return blocks, errors.Wrapf(err, "Failed to parse URL")
-  }
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		log.Error(err, "Failed to parse URL")
+		return blocks, errors.Wrapf(err, "Failed to parse URL")
+	}
 
-  u := url.URL{Scheme: "ws", Host: base.Host, Path: "/ws"}
-  log.Info("connecting to", "host", u.String())
+	u := url.URL{Scheme: "ws", Host: base.Host, Path: "/ws"}
+	log.Info("connecting to", "host", u.String())
 
-  c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to dial; %v", err)
-  }
-  defer c.Close()
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to dial; %v", err)
+	}
+	defer c.Close()
 
-  // Send one command
-  if err := sendExecuteRequest(c, newExecuteRequest([]string{"ls -la"})); err != nil {
-    return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
-  }
+	// Send one command
+	if err := sendExecuteRequest(c, newExecuteRequest([]string{"ls -la"})); err != nil {
+		return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
+	}
 
-  // Wait for the command to finish.
-  block, err := waitForCommandToFinish(c)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
-  }
+	// Wait for the command to finish.
+	block, err := waitForCommandToFinish(c)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
+	}
 
-  log.Info("Block", "block", logs.ZapProto("block", block))
+	log.Info("Block", "block", logs.ZapProto("block", block))
 
-  // Send second command
-  if err := sendExecuteRequest(c, newExecuteRequest([]string{"echo The date is $(DATE)"})); err != nil {
-    return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
-  }
+	// Send second command
+	if err := sendExecuteRequest(c, newExecuteRequest([]string{"echo The date is $(DATE)"})); err != nil {
+		return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
+	}
 
-  // Wait for the command to finish.
-  block, err = waitForCommandToFinish(c)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
-  }
+	// Wait for the command to finish.
+	block, err = waitForCommandToFinish(c)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
+	}
 
-  log.Info("Block", "block", logs.ZapProto("block", block))
+	log.Info("Block", "block", logs.ZapProto("block", block))
 
-  return blocks, nil
+	return blocks, nil
 }
 
 func runRunmeClientConcurrent(baseURL string) (map[string]any, error) {
-  interrupt := make(chan os.Signal, 1)
-  signal.Notify(interrupt, os.Interrupt)
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
 
-  log := logs.NewLogger()
+	log := logs.NewLogger()
 
-  blocks := make(map[string]any)
+	blocks := make(map[string]any)
 
-  base, err := url.Parse(baseURL)
-  if err != nil {
-    log.Error(err, "Failed to parse URL")
-    return blocks, errors.Wrapf(err, "Failed to parse URL")
-  }
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		log.Error(err, "Failed to parse URL")
+		return blocks, errors.Wrapf(err, "Failed to parse URL")
+	}
 
-  u := url.URL{Scheme: "ws", Host: base.Host, Path: "/ws"}
-  log.Info("connecting to", "host", u.String())
+	u := url.URL{Scheme: "ws", Host: base.Host, Path: "/ws"}
+	log.Info("connecting to", "host", u.String())
 
-  c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to dial; %v", err)
-  }
-  defer c.Close()
+	c, _, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to dial; %v", err)
+	}
+	defer c.Close()
 
-  req := newExecuteRequest([]string{`
+	req := newExecuteRequest([]string{`
 for i in {1..10}
 do
   echo "hello world - from 1"
   sleep 1
 done`})
 
-  // Send one command
-  if err := sendExecuteRequest(c, req); err != nil {
-    return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
-  }
+	// Send one command
+	if err := sendExecuteRequest(c, req); err != nil {
+		return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
+	}
 
-  req2 := newExecuteRequest([]string{`
+	req2 := newExecuteRequest([]string{`
 for i in {1..10}
 do
   echo "hello world - from 2"
   sleep 1
 done`})
 
-  // Send second command
-  if err := sendExecuteRequest(c, req2); err != nil {
-    return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
-  }
+	// Send second command
+	if err := sendExecuteRequest(c, req2); err != nil {
+		return blocks, errors.Wrapf(err, "Failed to send execute request; %v", err)
+	}
 
-  // Wait for the command to finish.
-  block, err := waitForCommandToFinish(c)
-  if err != nil {
-    return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
-  }
+	// Wait for the command to finish.
+	block, err := waitForCommandToFinish(c)
+	if err != nil {
+		return blocks, errors.Wrapf(err, "Failed to wait for command to finish; %v", err)
+	}
 
-  log.Info("Block", "block", logs.ZapProto("block", block))
+	log.Info("Block", "block", logs.ZapProto("block", block))
 
-  return blocks, nil
+	return blocks, nil
 }
 
 // newExecuteRequest is a helper function to create an ExecuteRequest.
 func newExecuteRequest(commands []string) *v2.ExecuteRequest {
-  executeRequest := &v2.ExecuteRequest{
-    Config: &v2.ProgramConfig{
-      ProgramName:   "/bin/zsh",
-      Arguments:     make([]string, 0),
-      LanguageId:    "sh",
-      Background:    false,
-      FileExtension: "",
-      Env: []string{
-        `RUNME_ID=${blockID}`,
-        "RUNME_RUNNER=v2",
-        "TERM=xterm-256color",
-      },
-      Source: &v2.ProgramConfig_Commands{
-        Commands: &v2.ProgramConfig_CommandList{
-          Items: commands,
-        },
-      },
-      Interactive: true,
-      Mode:        v2.CommandMode_COMMAND_MODE_INLINE,
-      KnownId:     uuid.NewString(),
-    },
-    Winsize: &v2.Winsize{Rows: 34, Cols: 100, X: 0, Y: 0},
-  }
-  return executeRequest
+	executeRequest := &v2.ExecuteRequest{
+		Config: &v2.ProgramConfig{
+			ProgramName:   "/bin/zsh",
+			Arguments:     make([]string, 0),
+			LanguageId:    "sh",
+			Background:    false,
+			FileExtension: "",
+			Env: []string{
+				`RUNME_ID=${blockID}`,
+				"RUNME_RUNNER=v2",
+				"TERM=xterm-256color",
+			},
+			Source: &v2.ProgramConfig_Commands{
+				Commands: &v2.ProgramConfig_CommandList{
+					Items: commands,
+				},
+			},
+			Interactive: true,
+			Mode:        v2.CommandMode_COMMAND_MODE_INLINE,
+			KnownId:     uuid.NewString(),
+		},
+		Winsize: &v2.Winsize{Rows: 34, Cols: 100, X: 0, Y: 0},
+	}
+	return executeRequest
 }
 
 // sendExecuteRequest sends an ExecuteRequest to the server.
 func sendExecuteRequest(c *websocket.Conn, executeRequest *v2.ExecuteRequest) error {
-  socketRequest := &cassie.SocketRequest{
-    Payload: &cassie.SocketRequest_ExecuteRequest{
-      ExecuteRequest: executeRequest,
-    },
-  }
+	socketRequest := &cassie.SocketRequest{
+		Payload: &cassie.SocketRequest_ExecuteRequest{
+			ExecuteRequest: executeRequest,
+		},
+	}
 
-  message, err := protojson.Marshal(socketRequest)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to marshal message; %v", err)
-  }
+	message, err := protojson.Marshal(socketRequest)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to marshal message; %v", err)
+	}
 
-  err = c.WriteMessage(websocket.TextMessage, []byte(message))
-  if err != nil {
-    return errors.Wrapf(err, "Failed to write message; %v", err)
-  }
-  return nil
+	err = c.WriteMessage(websocket.TextMessage, []byte(message))
+	if err != nil {
+		return errors.Wrapf(err, "Failed to write message; %v", err)
+	}
+	return nil
 }
 
 func waitForCommandToFinish(c *websocket.Conn) (*cassie.Block, error) {
-  log := logs.NewLogger()
+	log := logs.NewLogger()
 
-  block := &cassie.Block{
-    Outputs: make([]*cassie.BlockOutput, 0),
-  }
+	block := &cassie.Block{
+		Outputs: make([]*cassie.BlockOutput, 0),
+	}
 
-  block.Outputs = append(block.Outputs, &cassie.BlockOutput{
+	block.Outputs = append(block.Outputs, &cassie.BlockOutput{
 
-    Items: []*cassie.BlockOutputItem{
-      {
-        TextData: "",
-      },
-      {
-        TextData: "",
-      },
-    },
-  })
-  for {
-    _, message, err := c.ReadMessage()
-    if err != nil {
-      log.Error(err, "read error")
-    }
+		Items: []*cassie.BlockOutputItem{
+			{
+				TextData: "",
+			},
+			{
+				TextData: "",
+			},
+		},
+	})
+	for {
+		_, message, err := c.ReadMessage()
+		if err != nil {
+			log.Error(err, "read error")
+		}
 
-    response := &cassie.SocketResponse{}
-    if err := protojson.Unmarshal(message, response); err != nil {
-      log.Error(err, "Failed to unmarshal message")
-      return block, errors.Wrapf(err, "Failed to unmarshal message; %v", err)
-    }
-    if response.GetExecuteResponse() != nil {
-      resp := response.GetExecuteResponse()
+		response := &cassie.SocketResponse{}
+		if err := protojson.Unmarshal(message, response); err != nil {
+			log.Error(err, "Failed to unmarshal message")
+			return block, errors.Wrapf(err, "Failed to unmarshal message; %v", err)
+		}
+		if response.GetExecuteResponse() != nil {
+			resp := response.GetExecuteResponse()
 
-      block.Outputs[0].Items[0].TextData += string(resp.StdoutData)
-      block.Outputs[0].Items[1].TextData += string(resp.StderrData)
+			block.Outputs[0].Items[0].TextData += string(resp.StdoutData)
+			block.Outputs[0].Items[1].TextData += string(resp.StderrData)
 
-      if resp.GetExitCode() != nil {
-        // Use ExitCode to determine if the message indicates the end of the program
-        return block, nil
-      }
-      log.Info("Command Response", "stdout", string(resp.StdoutData), "stderr", string(resp.StderrData), "exitCode", resp.ExitCode)
-    } else {
-      log.Info("received", "message", string(message))
-    }
-  }
+			if resp.GetExitCode() != nil {
+				// Use ExitCode to determine if the message indicates the end of the program
+				return block, nil
+			}
+			log.Info("Command Response", "stdout", string(resp.StdoutData), "stderr", string(resp.StderrData), "exitCode", resp.ExitCode)
+		} else {
+			log.Info("received", "message", string(message))
+		}
+	}
 
 }
 
 func SkipIfMissing(t *testing.T, env string) string {
-  t.Helper()
-  if value, ok := os.LookupEnv(env); ok {
-    return value
-  }
-  t.Skipf("missing %s", env)
-  return ""
+	t.Helper()
+	if value, ok := os.LookupEnv(env); ok {
+		return value
+	}
+	t.Skipf("missing %s", env)
+	return ""
 }

--- a/docs/securing-the-runner.md
+++ b/docs/securing-the-runner.md
@@ -1,0 +1,77 @@
+---
+title: Securing the Runner
+---
+
+## Overview
+
+Since the runner grants the ability to execute arbitrary code, you should secure by enabling OIDC and
+restricting access to the runner to authorized users. The Cloud Assistant uses OIDC and your identity
+provider to authenticate users. The runner then enforces authorization policies to restrict access.
+
+## Enable OIDC
+
+To enable OIDC you need to fill out the `assistantServer.oidc` section of the configuration file
+`~/.cloud-assistant/config.yaml`
+
+```yaml
+apiVersion: ""
+kind: Config
+assistantServer:
+    ...
+    oidc:
+      google:
+        clientCredentialsFile: /Users/${USER}/.cloud-assistant/client_credentials.json
+        discoveryURL: https://accounts.google.com/.well-known/openid-configuration
+      generic:
+        clientID: your-client-id-here
+        clientSecret: your-client-secret-here
+        redirectURL: http://localhost:8080/auth/callback
+        discoveryURL: https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+        scopes:
+          - "openid"
+          - "email"
+        issuer: https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0 # TODO: change this to your own tenant ID
+      forceApproval: false # helpful for troubleshooting issues with OIDC
+```
+
+The section you fill out will depend on your OpenID provider.
+
+### Microsoft Entra ID
+
+For Microsoft Entra ID, your OIDC config should look like
+
+```
+assistantServer:
+  oidc:
+    generic:
+        clientID: <YOUR CLIENT ID>
+        clientSecret: <YOUR CLIENT SECRET>
+        redirectURL: http://localhost:8080/oidc/callback
+        discoveryURL: https://login.microsoftonline.com/<TENANT ID>/v2.0/.well-known/openid-configuration
+        scopes:
+            - "openid"
+            - "email"
+        issuer: https://login.microsoftonline.com/<TENANT ID>/v2.0
+```
+
+## Configure an IAM Policy
+
+You configure an IAM policy to restrict users who can access the agent and runner as illusrated below.
+
+
+```
+kind: Config
+...
+iamPolicy:
+    bindings:
+    - role: role/agent.user
+      members:
+      - name: bob@acme.com
+    - role: role/runner.user
+      members:
+      - name: bob@acme.com
+```
+
+
+
+


### PR DESCRIPTION
This PR improves the AuthZ logic added in the original OIDC implementation.

The original PR added the ability to Authorize based on users being in a given domain. We need finer grained authorization at the individual level. For example, a runner (e.g. on localhost or devbox) might be restricted to a single user.

This PR introduces IAM Policies, Roles, and Binding modeled on how GCP handles IAM. We can then define an IAM policy which grants certain roles to individual users. Currently two roles are defined runner.user and agent.user. 
Currently members can only be specified as individuals. In the future we could extend it to all "all users in a domain", "groups" or similar semantics based on requirements.

This PR also starts storing the OIDC token in the context and then passing that along to a separate Auth middle ware that handles AuthZ. This allows us to have method specific authorization handling.

