### PR TITLE
Only redirect to login when APIs are unauthorized

### DIFF
--- a/web/src/components/Runme/Console.tsx
+++ b/web/src/components/Runme/Console.tsx
@@ -170,6 +170,15 @@ function Console({
     }
 
     socket = createWebSocket(settings.runnerEndpoint)
+
+    socket.onclose = (e: CloseEvent) => {
+      if (e.code <= 1000) {
+        return
+      }
+
+      console.error('WebSocket closed with code:', e.code)
+    }
+
     socket.onmessage = (event) => {
       if (typeof event.data !== 'string') {
         console.warn('Unexpected WebSocket message type:', typeof event.data)

--- a/web/src/contexts/BlockContext.tsx
+++ b/web/src/contexts/BlockContext.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, createContext, useContext, useMemo, useState } from 'react'
 
 import { clone, create } from '@bufbuild/protobuf'
-import { ConnectError } from '@connectrpc/connect'
 import { v4 as uuidv4 } from 'uuid'
 
 import {
@@ -52,15 +51,6 @@ export const useBlock = () => {
 interface BlockState {
   blocks: Record<string, Block>
   positions: string[]
-}
-
-const handleConnectError = (error: unknown) => {
-  console.error(error)
-  const connectErr = ConnectError.from(error)
-  // todo: This code is always internal error, let's figure out why later
-  if (connectErr.code) {
-    window.location.href = `/login?error=${encodeURIComponent(connectErr.name)}&error_description=${encodeURIComponent(connectErr.rawMessage)}`
-  }
 }
 
 export const BlockProvider = ({ children }: { children: ReactNode }) => {
@@ -139,7 +129,7 @@ export const BlockProvider = ({ children }: { children: ReactNode }) => {
         setPreviousResponseId(r.responseId)
       }
     } catch (e) {
-      handleConnectError(e)
+      console.log(e)
     } finally {
       setIsTyping(false)
       setIsInputDisabled(false)


### PR DESCRIPTION
As discussed in #45.

Please note that the `cassie-session` cookie will expire after 12h now. It turns out that true session cookies are pinned to the browser app (not the tab) lifetime.