### PR TITLE
Domain Auth and Better Runner Support

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      # For testing the changes to the workflow to tag the commit and allow workflow dispatch. 
+      # We can get rid of this once we are happy with the updated workflow
+      - jlewi/oidc
   # Allow manual triggering
   # This allows building images from branches
   workflow_dispatch: {}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -35,4 +35,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:commit-${{ github.sha.substring(0, 7) }}
+            ghcr.io/${{ github.repository }}:commit-${{ format('{0}', github.sha | slice(0, 7)) }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Allow manual triggering
+  # This allows building images from branches
+  workflow_dispatch: {}
 
 jobs:
   build-and-push:
@@ -27,4 +30,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:commit-${{ github.sha::7 }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -27,7 +27,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      # GITHUB doesn't provide the short SHA automatically
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
@@ -35,4 +41,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:commit-${{ format('{0}', github.sha | slice(0, 7)) }}
+            ghcr.io/${{ github.repository }}:commit-${{  env.COMMIT_SHORT_SHA }}

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -35,4 +35,4 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository }}:commit-${{ github.sha::7 }}
+            ghcr.io/${{ github.repository }}:commit-${{ github.sha.substring(0, 7) }}

--- a/app/api/iam.go
+++ b/app/api/iam.go
@@ -8,6 +8,13 @@ const (
 	AgentUserRole = "role/agent.user"
 )
 
+type MemberKind string
+
+const (
+	UserKind   MemberKind = "user"
+	DomainKind MemberKind = "domain"
+)
+
 // IAMPolicy is a policy that defines the access control for the service.
 type IAMPolicy struct {
 	// Bindings is a list of bindings that define the access control for the service.
@@ -28,5 +35,6 @@ type Member struct {
 	// Name is the name of the member. e.g. jlewi@acme.com
 	// N.B. In the future we could add a kind field to indicate what type of member it is
 	// (e.g.domain, serviceaccount, group).
-	Name string `json:"name" yaml:"name"`
+	Name string     `json:"name" yaml:"name"`
+	Kind MemberKind `json:"kind" yaml:"kind"`
 }

--- a/app/pkg/config/config.go
+++ b/app/pkg/config/config.go
@@ -354,9 +354,6 @@ type OIDCConfig struct {
 	// Generic contains generic OIDC configuration
 	Generic *GenericOIDCConfig `json:"generic,omitempty" yaml:"generic,omitempty"`
 
-	// Domains is a list of allowed domains for OIDC authentication
-	Domains []string `json:"domains" yaml:"domains"`
-
 	// ForceApproval is a flag to force the user to approve the app again
 	ForceApproval bool `json:"forceApproval" yaml:"forceApproval"`
 }

--- a/app/pkg/iam/checker_test.go
+++ b/app/pkg/iam/checker_test.go
@@ -7,6 +7,34 @@ import (
 )
 
 func TestChecker_Check(t *testing.T) {
+
+	complexPolicy := api.IAMPolicy{
+		Bindings: []api.IAMBinding{
+			{
+				Role: api.RunnerUserRole,
+				Members: []api.Member{
+					{
+						Name: "user1",
+						Kind: api.UserKind,
+					},
+					{
+						Name: "acme.com",
+						Kind: api.DomainKind,
+					},
+				},
+			},
+			{
+				Role: api.AgentUserRole,
+				Members: []api.Member{
+					{
+						Name: "user2",
+						Kind: api.UserKind,
+					},
+				},
+			},
+		},
+	}
+
 	testCases := []struct {
 		name      string
 		principal string
@@ -15,36 +43,34 @@ func TestChecker_Check(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name:      "User has role",
-			principal: "user1",
+			name:      "User doesn't have role",
+			principal: "bob@beta.com",
 			role:      api.RunnerUserRole,
-			policy: api.IAMPolicy{
-				Bindings: []api.IAMBinding{
-					{
-						Role: api.RunnerUserRole,
-						Members: []api.Member{
-							{Name: "user1"},
-						},
-					},
-				},
-			},
-			expected: true,
+			policy:    complexPolicy,
+			expected:  false,
 		},
 		{
-			name:      "User doesn't have role",
-			principal: "user2",
+			name:      "Domain has role",
+			principal: "alice@acme.com",
 			role:      api.RunnerUserRole,
-			policy: api.IAMPolicy{
-				Bindings: []api.IAMBinding{
-					{
-						Role: api.RunnerUserRole,
-						Members: []api.Member{
-							{Name: "user1"},
-						},
-					},
-				},
-			},
-			expected: false,
+			policy:    complexPolicy,
+			expected:  true,
+		},
+		{
+			// This test is intended to verify that the domain rule gets correctly
+			// scoped to the role. Alice should have runner access but not agent access
+			name:      "Role doesn't have domain rule but other does",
+			principal: "alice@acme.com",
+			role:      api.AgentUserRole,
+			policy:    complexPolicy,
+			expected:  false,
+		},
+		{
+			name:      "User1 is allowed under member rule not domain rule",
+			principal: "user1",
+			role:      api.RunnerUserRole,
+			policy:    complexPolicy,
+			expected:  true,
 		},
 	}
 

--- a/app/pkg/iam/domain.go
+++ b/app/pkg/iam/domain.go
@@ -1,0 +1,17 @@
+package iam
+
+import "strings"
+
+// domainMatcher checks whether the principal is a member of a domain
+type domainMatcher struct {
+	domain string
+}
+
+func (m *domainMatcher) Check(principal string) bool {
+	pieces := strings.Split(principal, "@")
+	if len(pieces) != 2 {
+		return false
+	}
+
+	return pieces[1] == m.domain
+}

--- a/app/pkg/iam/domain_test.go
+++ b/app/pkg/iam/domain_test.go
@@ -1,0 +1,48 @@
+package iam
+
+import (
+	"testing"
+)
+
+func TestDomainMatcher_Check(t *testing.T) {
+	tests := []struct {
+		domain    string
+		principal string
+		want      bool
+	}{
+		{
+			domain:    "example.com",
+			principal: "user@example.com",
+			want:      true,
+		},
+		{
+			domain:    "example.org",
+			principal: "user@example.com",
+			want:      false,
+		},
+		{
+			domain:    "example.com",
+			principal: "user@sub.example.com",
+			want:      false,
+		},
+		{
+			domain:    "example.com",
+			principal: "invalid-email",
+			want:      false,
+		},
+		{
+			domain:    "example.com",
+			principal: "another@example.com",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.principal, func(t *testing.T) {
+			matcher := &domainMatcher{domain: tt.domain}
+			if got := matcher.Check(tt.principal); got != tt.want {
+				t.Errorf("domainMatcher.Check() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -1,33 +1,33 @@
 package server
 
 import (
-  "context"
-  "crypto/rand"
-  "crypto/rsa"
-  "encoding/base64"
-  "encoding/json"
-  "fmt"
-  "math/big"
-  "net/http"
-  "net/url"
-  "os"
-  "slices"
-  "strings"
-  "sync"
-  "time"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
 
-  "github.com/jlewi/cloud-assistant/app/pkg/iam"
-  "github.com/jlewi/cloud-assistant/app/pkg/logs"
+	"github.com/jlewi/cloud-assistant/app/pkg/iam"
+	"github.com/jlewi/cloud-assistant/app/pkg/logs"
 
-  connectcors "connectrpc.com/cors"
-  "github.com/go-logr/zapr"
-  "github.com/golang-jwt/jwt/v5"
-  "github.com/jlewi/cloud-assistant/app/pkg/config"
-  "github.com/pkg/errors"
-  "github.com/rs/cors"
-  "go.uber.org/zap"
-  "golang.org/x/oauth2"
-  "golang.org/x/oauth2/google"
+	connectcors "connectrpc.com/cors"
+	"github.com/go-logr/zapr"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
+	"github.com/pkg/errors"
+	"github.com/rs/cors"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 )
 
 // IDTokenKeyType  string is the key used to store the ID token in the context
@@ -35,103 +35,103 @@ import (
 type IDTokenKeyType string
 
 const (
-  oidcPathPrefix                   = "/oidc"
-  sessionCookieName                = "cassie-session"
-  stateLength                      = 32
-  IDTokenKey        IDTokenKeyType = "idToken"
+	oidcPathPrefix                   = "/oidc"
+	sessionCookieName                = "cassie-session"
+	stateLength                      = 32
+	IDTokenKey        IDTokenKeyType = "idToken"
 )
 
 // OIDC handles OAuth2 authentication setup and management
 type OIDC struct {
-  config     *config.OIDCConfig
-  oauth2     *oauth2.Config
-  publicKeys map[string]*rsa.PublicKey
-  discovery  *openIDDiscovery
-  state      *stateManager
-  provider   OIDCProvider
+	config     *config.OIDCConfig
+	oauth2     *oauth2.Config
+	publicKeys map[string]*rsa.PublicKey
+	discovery  *openIDDiscovery
+	state      *stateManager
+	provider   OIDCProvider
 }
 
 // newOIDC creates a new OIDC
 func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
-  if cfg == nil {
-    return nil, nil
-  }
+	if cfg == nil {
+		return nil, nil
+	}
 
-  // Check that only one provider is configured
-  if cfg.Google != nil && cfg.Generic != nil {
-    return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
-  }
+	// Check that only one provider is configured
+	if cfg.Google != nil && cfg.Generic != nil {
+		return nil, errors.New("both Google and generic OIDC providers cannot be configured at the same time")
+	}
 
-  if cfg.Google == nil && cfg.Generic == nil {
-    return nil, nil
-  }
+	if cfg.Google == nil && cfg.Generic == nil {
+		return nil, nil
+	}
 
-  var provider OIDCProvider
-  if cfg.Google != nil {
-    provider = NewGoogleProvider(cfg.Google)
-  } else {
-    provider = NewGenericProvider(cfg.Generic)
-  }
+	var provider OIDCProvider
+	if cfg.Google != nil {
+		provider = NewGoogleProvider(cfg.Google)
+	} else {
+		provider = NewGenericProvider(cfg.Generic)
+	}
 
-  oauth2Config, err := provider.GetOAuth2Config()
-  if err != nil {
-    return nil, err
-  }
+	oauth2Config, err := provider.GetOAuth2Config()
+	if err != nil {
+		return nil, err
+	}
 
-  discoveryURL := provider.GetDiscoveryURL()
+	discoveryURL := provider.GetDiscoveryURL()
 
-  // Fetch the OpenID configuration
-  resp, err := http.Get(discoveryURL)
-  if err != nil {
-    return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
-  }
-  defer func() {
-    if err := resp.Body.Close(); err != nil {
-      zap.L().Error("failed to close response body", zap.Error(err))
-    }
-  }()
+	// Fetch the OpenID configuration
+	resp, err := http.Get(discoveryURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to fetch OpenID configuration")
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
-  var discovery openIDDiscovery
-  if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
-    return nil, errors.Wrap(err, "failed to decode OpenID configuration")
-  }
+	var discovery openIDDiscovery
+	if err := json.NewDecoder(resp.Body).Decode(&discovery); err != nil {
+		return nil, errors.Wrap(err, "failed to decode OpenID configuration")
+	}
 
-  // Update endpoints from discovery document
-  oauth2Config.Endpoint = oauth2.Endpoint{
-    AuthURL:  discovery.AuthURL,
-    TokenURL: discovery.TokenURL,
-  }
+	// Update endpoints from discovery document
+	oauth2Config.Endpoint = oauth2.Endpoint{
+		AuthURL:  discovery.AuthURL,
+		TokenURL: discovery.TokenURL,
+	}
 
-  // If the generic provider is configured with an issuer, use it
-  if cfg.Generic != nil && cfg.Generic.Issuer != "" {
-    discovery.Issuer = cfg.Generic.Issuer
-  }
+	// If the generic provider is configured with an issuer, use it
+	if cfg.Generic != nil && cfg.Generic.Issuer != "" {
+		discovery.Issuer = cfg.Generic.Issuer
+	}
 
-  // Initialize OIDC
-  oidc := &OIDC{
-    config:     cfg,
-    oauth2:     oauth2Config,
-    publicKeys: make(map[string]*rsa.PublicKey),
-    discovery:  &discovery,
-    state:      newStateManager(10 * time.Minute),
-    provider:   provider,
-  }
+	// Initialize OIDC
+	oidc := &OIDC{
+		config:     cfg,
+		oauth2:     oauth2Config,
+		publicKeys: make(map[string]*rsa.PublicKey),
+		discovery:  &discovery,
+		state:      newStateManager(10 * time.Minute),
+		provider:   provider,
+	}
 
-  // Download JWKS for signature verification
-  if err := oidc.downloadJWKS(); err != nil {
-    return nil, errors.Wrapf(err, "Failed to download JWKS")
-  }
+	// Download JWKS for signature verification
+	if err := oidc.downloadJWKS(); err != nil {
+		return nil, errors.Wrapf(err, "Failed to download JWKS")
+	}
 
-  // Start a goroutine to clean up expired states
-  go func() {
-    ticker := time.NewTicker(oidc.state.stateExpiration / 2)
-    defer ticker.Stop()
-    for range ticker.C {
-      oidc.state.cleanupExpiredStates()
-    }
-  }()
+	// Start a goroutine to clean up expired states
+	go func() {
+		ticker := time.NewTicker(oidc.state.stateExpiration / 2)
+		defer ticker.Stop()
+		for range ticker.C {
+			oidc.state.cleanupExpiredStates()
+		}
+	}()
 
-  return oidc, nil
+	return oidc, nil
 }
 
 // downloadJWKS downloads the JSON Web Key Set (JWKS) from Google's OAuth2 provider.
@@ -140,601 +140,601 @@ func newOIDC(cfg *config.OIDCConfig) (*OIDC, error) {
 // This allows the application to verify tokens offline without contacting Google's servers
 // for each verification request.
 func (o *OIDC) downloadJWKS() error {
-  // Fetch the JWKS from the URI specified in the discovery document
-  resp, err := http.Get(o.discovery.JWKSURI)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
-  }
-  defer func() {
-    if err := resp.Body.Close(); err != nil {
-      zap.L().Error("failed to close response body", zap.Error(err))
-    }
-  }()
+	// Fetch the JWKS from the URI specified in the discovery document
+	resp, err := http.Get(o.discovery.JWKSURI)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to fetch JWKS from %s", o.discovery.JWKSURI)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			zap.L().Error("failed to close response body", zap.Error(err))
+		}
+	}()
 
-  // Parse the JWKS into our structured format
-  var jwks jwks
-  if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
-    return errors.Wrapf(err, "Failed to parse JWKS response")
-  }
+	// Parse the JWKS into our structured format
+	var jwks jwks
+	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+		return errors.Wrapf(err, "Failed to parse JWKS response")
+	}
 
-  // Convert each key to RSA public key and store in the map
-  for _, key := range jwks.Keys {
-    // Convert the modulus and exponent from base64url to *rsa.PublicKey
-    n, err := base64.RawURLEncoding.DecodeString(key.N)
-    if err != nil {
-      return errors.Wrap(err, "failed to decode modulus")
-    }
+	// Convert each key to RSA public key and store in the map
+	for _, key := range jwks.Keys {
+		// Convert the modulus and exponent from base64url to *rsa.PublicKey
+		n, err := base64.RawURLEncoding.DecodeString(key.N)
+		if err != nil {
+			return errors.Wrap(err, "failed to decode modulus")
+		}
 
-    e, err := base64.RawURLEncoding.DecodeString(key.E)
-    if err != nil {
-      return errors.Wrap(err, "failed to decode exponent")
-    }
+		e, err := base64.RawURLEncoding.DecodeString(key.E)
+		if err != nil {
+			return errors.Wrap(err, "failed to decode exponent")
+		}
 
-    // Convert the modulus to a big integer
-    modulus := new(big.Int).SetBytes(n)
+		// Convert the modulus to a big integer
+		modulus := new(big.Int).SetBytes(n)
 
-    // Convert the exponent to an integer
-    var exponent int
-    if len(e) < 4 {
-      for i := range e {
-        exponent = exponent<<8 + int(e[i])
-      }
-    } else {
-      return errors.New("exponent too large")
-    }
+		// Convert the exponent to an integer
+		var exponent int
+		if len(e) < 4 {
+			for i := range e {
+				exponent = exponent<<8 + int(e[i])
+			}
+		} else {
+			return errors.New("exponent too large")
+		}
 
-    // Create the RSA public key
-    publicKey := &rsa.PublicKey{
-      N: modulus,
-      E: exponent,
-    }
+		// Create the RSA public key
+		publicKey := &rsa.PublicKey{
+			N: modulus,
+			E: exponent,
+		}
 
-    // Store the public key in the map using the kid as the key
-    o.publicKeys[key.Kid] = publicKey
-  }
+		// Store the public key in the map using the kid as the key
+		o.publicKeys[key.Kid] = publicKey
+	}
 
-  return nil
+	return nil
 }
 
 // verifyToken verifies the JWT token and returns whether it's valid and any error encountered
 // result is nil if its an invalid token and non-nil if its valid
 func (o *OIDC) verifyToken(idToken string) (*jwt.Token, error) {
-  // Verify the token signature using JWKS
-  token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
-    // Verify the signing method is what we expect
-    if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-      return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-    }
+	// Verify the token signature using JWKS
+	token, err := jwt.Parse(idToken, func(token *jwt.Token) (any, error) {
+		// Verify the signing method is what we expect
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
 
-    // Get the key ID from the token header
-    kid, ok := token.Header["kid"].(string)
-    if !ok {
-      return nil, errors.New("kid header not found in token")
-    }
+		// Get the key ID from the token header
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, errors.New("kid header not found in token")
+		}
 
-    // Get the public key from our map
-    publicKey, ok := o.publicKeys[kid]
-    if !ok {
-      return nil, errors.New("unable to find appropriate key")
-    }
+		// Get the public key from our map
+		publicKey, ok := o.publicKeys[kid]
+		if !ok {
+			return nil, errors.New("unable to find appropriate key")
+		}
 
-    return publicKey, nil
-  })
+		return publicKey, nil
+	})
 
-  if err != nil || !token.Valid {
-    return nil, fmt.Errorf("invalid token signature: %v", err)
-  }
+	if err != nil || !token.Valid {
+		return nil, fmt.Errorf("invalid token signature: %v", err)
+	}
 
-  // Get the claims from the token
-  claims, ok := token.Claims.(jwt.MapClaims)
-  if !ok {
-    return nil, errors.New("failed to get claims from token")
-  }
+	// Get the claims from the token
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok {
+		return nil, errors.New("failed to get claims from token")
+	}
 
-  // Verify expiration
-  exp, err := claims.GetExpirationTime()
-  if err != nil {
-    return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
-  }
-  if time.Now().After(exp.Time) {
-    return nil, errors.New("token expired")
-  }
+	// Verify expiration
+	exp, err := claims.GetExpirationTime()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get expiration from claims: %v", err)
+	}
+	if time.Now().After(exp.Time) {
+		return nil, errors.New("token expired")
+	}
 
-  // Verify issuer
-  iss, err := claims.GetIssuer()
-  if err != nil || iss != o.discovery.Issuer {
-    return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
-  }
+	// Verify issuer
+	iss, err := claims.GetIssuer()
+	if err != nil || iss != o.discovery.Issuer {
+		return nil, fmt.Errorf("invalid token issuer: got %v, expected %v", iss, o.discovery.Issuer)
+	}
 
-  // Verify audience matches our client ID
-  aud, err := claims.GetAudience()
-  if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
-    return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
-  }
+	// Verify audience matches our client ID
+	aud, err := claims.GetAudience()
+	if err != nil || len(aud) == 0 || aud[0] != o.oauth2.ClientID {
+		return nil, fmt.Errorf("invalid token audience: got %v, expected %v", aud, o.oauth2.ClientID)
+	}
 
-  return token, nil
+	return token, nil
 }
 
 // RegisterAuthRoutes registers the OAuth2 authentication routes
 func RegisterAuthRoutes(config *config.OIDCConfig, mux *AuthMux) error {
-  if config == nil {
-    return nil
-  }
+	if config == nil {
+		return nil
+	}
 
-  oidc, err := newOIDC(config)
-  if err != nil {
-    return errors.Wrapf(err, "Failed to create OAuth2 manager")
-  }
+	oidc, err := newOIDC(config)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to create OAuth2 manager")
+	}
 
-  // Register OAuth2 endpoints
-  mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
-  mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
-  mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
-  mux.HandleFunc("/logout", oidc.logoutHandler)
+	// Register OAuth2 endpoints
+	mux.HandleFunc(oidcPathPrefix+"/login", oidc.loginHandler)
+	mux.HandleFunc(oidcPathPrefix+"/callback", oidc.callbackHandler)
+	mux.HandleFunc(oidcPathPrefix+"/logout", oidc.logoutHandler)
+	mux.HandleFunc("/logout", oidc.logoutHandler)
 
-  return nil
+	return nil
 }
 
 // NewAuthMiddleware creates a middleware that enforces OIDC authentication
 func NewAuthMiddleware(config *config.OIDCConfig) (func(http.Handler) http.Handler, error) {
-  if config == nil {
-    // Return a no-op middleware if OIDC is not configured
-    return func(next http.Handler) http.Handler {
-      return next
-    }, nil
-  }
+	if config == nil {
+		// Return a no-op middleware if OIDC is not configured
+		return func(next http.Handler) http.Handler {
+			return next
+		}, nil
+	}
 
-  oidc, err := newOIDC(config)
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
-  }
-  return newAuthMiddlewareForOIDC(oidc)
+	oidc, err := newOIDC(config)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create OAuth2 manager")
+	}
+	return newAuthMiddlewareForOIDC(oidc)
 }
 
 // newAuthMiddlewareForOIDC allows our test to inject a mock OIDC
 func newAuthMiddlewareForOIDC(oidc *OIDC) (func(http.Handler) http.Handler, error) {
-  return func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-      log := zapr.NewLogger(zap.L())
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			log := zapr.NewLogger(zap.L())
 
-      // Skip authentication for login page and OAuth2 endpoints
-      if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
-        next.ServeHTTP(w, r)
-        return
-      }
+			// Skip authentication for login page and OAuth2 endpoints
+			if r.URL.Path == "/login" || strings.HasPrefix(r.URL.Path, oidcPathPrefix+"/") {
+				next.ServeHTTP(w, r)
+				return
+			}
 
-      // Get the session token from the cookie
-      cookie, err := r.Cookie(sessionCookieName)
-      if err != nil {
-        // No session cookie, return 401 Unauthorized
-        log.Error(err, "No session cookie found")
-        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-        return
-      }
+			// Get the session token from the cookie
+			cookie, err := r.Cookie(sessionCookieName)
+			if err != nil {
+				// No session cookie, return 401 Unauthorized
+				log.Error(err, "No session cookie found")
+				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+				return
+			}
 
-      // Verify the token by parsing and validating the JWT
-      idToken := cookie.Value
+			// Verify the token by parsing and validating the JWT
+			idToken := cookie.Value
 
-      token, err := oidc.verifyToken(idToken)
-      if token == nil {
-        log.Error(err, "Token validation failed")
-        // Return HTTP 401 and let the client handle the redirect to the login page
-        http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
-        return
-      }
+			token, err := oidc.verifyToken(idToken)
+			if token == nil {
+				log.Error(err, "Token validation failed")
+				// Return HTTP 401 and let the client handle the redirect to the login page
+				http.Error(w, "Unauthorized: Invalid or expired token", http.StatusUnauthorized)
+				return
+			}
 
-      // Add the IDToken to the context
-      ctx := context.WithValue(r.Context(), IDTokenKey, token)
+			// Add the IDToken to the context
+			ctx := context.WithValue(r.Context(), IDTokenKey, token)
 
-      // Token is valid, proceed with the request
-      next.ServeHTTP(w, r.WithContext(ctx))
-    })
-  }, nil
+			// Token is valid, proceed with the request
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}, nil
 }
 
 // loginHandler handles the OAuth2 login flow
 func (o *OIDC) loginHandler(w http.ResponseWriter, r *http.Request) {
-  state, err := o.state.generateState()
-  if err != nil {
-    log := zapr.NewLogger(zap.L())
-    log.Error(err, "Failed to generate state")
-    http.Error(w, "Internal server error", http.StatusInternalServerError)
-    return
-  }
-  url := o.oauth2.AuthCodeURL(state)
-  if o.config.ForceApproval {
-    url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
-  }
-  http.Redirect(w, r, url, http.StatusFound)
+	state, err := o.state.generateState()
+	if err != nil {
+		log := zapr.NewLogger(zap.L())
+		log.Error(err, "Failed to generate state")
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	url := o.oauth2.AuthCodeURL(state)
+	if o.config.ForceApproval {
+		url = o.oauth2.AuthCodeURL(state, oauth2.ApprovalForce)
+	}
+	http.Redirect(w, r, url, http.StatusFound)
 }
 
 // callbackHandler handles the OAuth2 callback
 func (o *OIDC) callbackHandler(w http.ResponseWriter, r *http.Request) {
-  log := zapr.NewLogger(zap.L())
+	log := zapr.NewLogger(zap.L())
 
-  // Verify state
-  state := r.URL.Query().Get("state")
-  if !o.state.validateState(state) {
-    log.Error(nil, "Invalid state parameter")
-    redirectWithError(w, r, "invalid_state", "Invalid state parameter")
-    return
-  }
+	// Verify state
+	state := r.URL.Query().Get("state")
+	if !o.state.validateState(state) {
+		log.Error(nil, "Invalid state parameter")
+		redirectWithError(w, r, "invalid_state", "Invalid state parameter")
+		return
+	}
 
-  // Exchange code for token
-  code := r.URL.Query().Get("code")
-  token, err := o.oauth2.Exchange(r.Context(), code)
-  if err != nil {
-    log.Error(err, "Failed to exchange code for token")
-    redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
-    return
-  }
+	// Exchange code for token
+	code := r.URL.Query().Get("code")
+	token, err := o.oauth2.Exchange(r.Context(), code)
+	if err != nil {
+		log.Error(err, "Failed to exchange code for token")
+		redirectWithError(w, r, "token_exchange_failed", "Failed to exchange code for token")
+		return
+	}
 
-  // Get the ID token from the response
-  idToken, ok := token.Extra("id_token").(string)
-  if !ok {
-    log.Error(nil, "No ID token in response")
-    redirectWithError(w, r, "no_id_token", "No ID token in response")
-    return
-  }
+	// Get the ID token from the response
+	idToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		log.Error(nil, "No ID token in response")
+		redirectWithError(w, r, "no_id_token", "No ID token in response")
+		return
+	}
 
-  // Set the session cookie with the ID token
-  http.SetCookie(w, &http.Cookie{
-    Name:     sessionCookieName,
-    Value:    idToken,
-    Path:     "/",
-    HttpOnly: true,
-    Secure:   true,
-    SameSite: http.SameSiteLaxMode,
-  })
+	// Set the session cookie with the ID token
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    idToken,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
 
-  // Redirect to the home page
-  http.Redirect(w, r, "/", http.StatusFound)
+	// Redirect to the home page
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // redirectWithError redirects to the login page with error information
 func redirectWithError(w http.ResponseWriter, r *http.Request, errorCode, errorDescription string) {
-  // Get any existing error parameters from the request
-  existingError := r.URL.Query().Get("error")
-  existingDescription := r.URL.Query().Get("error_description")
+	// Get any existing error parameters from the request
+	existingError := r.URL.Query().Get("error")
+	existingDescription := r.URL.Query().Get("error_description")
 
-  // Use existing error parameters if they exist, otherwise use the provided ones
-  if existingError == "" {
-    existingError = errorCode
-  }
-  if existingDescription == "" {
-    existingDescription = errorDescription
-  }
+	// Use existing error parameters if they exist, otherwise use the provided ones
+	if existingError == "" {
+		existingError = errorCode
+	}
+	if existingDescription == "" {
+		existingDescription = errorDescription
+	}
 
-  // Build the redirect URL with error parameters
-  redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
-    url.QueryEscape(existingError),
-    url.QueryEscape(existingDescription))
+	// Build the redirect URL with error parameters
+	redirectURL := fmt.Sprintf("/login?error=%s&error_description=%s",
+		url.QueryEscape(existingError),
+		url.QueryEscape(existingDescription))
 
-  http.Redirect(w, r, redirectURL, http.StatusFound)
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // logoutHandler handles the OAuth2 logout
 func (o *OIDC) logoutHandler(w http.ResponseWriter, r *http.Request) {
-  // Clear the session cookie
-  http.SetCookie(w, &http.Cookie{
-    Name:     sessionCookieName,
-    Value:    "",
-    Path:     "/",
-    HttpOnly: true,
-    Secure:   true,
-    SameSite: http.SameSiteLaxMode,
-    MaxAge:   -1,
-  })
+	// Clear the session cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
 
-  // Redirect to the home page
-  http.Redirect(w, r, "/", http.StatusFound)
+	// Redirect to the home page
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 type stateEntry struct {
-  expiresAt time.Time
+	expiresAt time.Time
 }
 
 type stateManager struct {
-  stateExpiration time.Duration
-  states          map[string]stateEntry
-  mu              sync.RWMutex
+	stateExpiration time.Duration
+	states          map[string]stateEntry
+	mu              sync.RWMutex
 }
 
 func newStateManager(stateExpiration time.Duration) *stateManager {
-  return &stateManager{
-    stateExpiration: stateExpiration,
-    states:          make(map[string]stateEntry),
-  }
+	return &stateManager{
+		stateExpiration: stateExpiration,
+		states:          make(map[string]stateEntry),
+	}
 }
 
 // generateState generates a new cryptographically secure random state
 func (sm *stateManager) generateState() (string, error) {
-  b := make([]byte, stateLength)
-  if _, err := rand.Read(b); err != nil {
-    return "", errors.Wrap(err, "failed to generate random state")
-  }
-  state := base64.URLEncoding.EncodeToString(b)
+	b := make([]byte, stateLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", errors.Wrap(err, "failed to generate random state")
+	}
+	state := base64.URLEncoding.EncodeToString(b)
 
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
-  sm.states[state] = stateEntry{
-    expiresAt: time.Now().Add(sm.stateExpiration),
-  }
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	sm.states[state] = stateEntry{
+		expiresAt: time.Now().Add(sm.stateExpiration),
+	}
 
-  return state, nil
+	return state, nil
 }
 
 // validateState checks if a state is valid and removes it if it is
 func (sm *stateManager) validateState(state string) bool {
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 
-  entry, exists := sm.states[state]
-  if !exists {
-    return false
-  }
+	entry, exists := sm.states[state]
+	if !exists {
+		return false
+	}
 
-  // Remove the state regardless of validity
-  delete(sm.states, state)
+	// Remove the state regardless of validity
+	delete(sm.states, state)
 
-  // Check if the state has expired
-  return time.Now().Before(entry.expiresAt)
+	// Check if the state has expired
+	return time.Now().Before(entry.expiresAt)
 }
 
 // cleanupExpiredStates removes expired states from the map
 func (sm *stateManager) cleanupExpiredStates() {
-  sm.mu.Lock()
-  defer sm.mu.Unlock()
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
 
-  now := time.Now()
-  for state, entry := range sm.states {
-    if now.After(entry.expiresAt) {
-      delete(sm.states, state)
-    }
-  }
+	now := time.Now()
+	for state, entry := range sm.states {
+		if now.After(entry.expiresAt) {
+			delete(sm.states, state)
+		}
+	}
 }
 
 // jwksKey represents a single key in the JWKS
 type jwksKey struct {
-  Kty string `json:"kty"`
-  Alg string `json:"alg"`
-  Use string `json:"use"`
-  Kid string `json:"kid"`
-  N   string `json:"n"`
-  E   string `json:"e"`
+	Kty string `json:"kty"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
 }
 
 // jwks represents the JSON Web Key Set
 type jwks struct {
-  Keys []jwksKey `json:"keys"`
+	Keys []jwksKey `json:"keys"`
 }
 
 // openIDDiscovery is the struct for parsing the discovery document
 type openIDDiscovery struct {
-  Issuer                           string   `json:"issuer"`
-  AuthURL                          string   `json:"authorization_endpoint"`
-  TokenURL                         string   `json:"token_endpoint"`
-  JWKSURI                          string   `json:"jwks_uri"`
-  UserInfoURL                      string   `json:"userinfo_endpoint"`
-  ScopesSupported                  []string `json:"scopes_supported"`
-  ResponseTypesSupported           []string `json:"response_types_supported"`
-  SubjectTypesSupported            []string `json:"subject_types_supported"`
-  IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	Issuer                           string   `json:"issuer"`
+	AuthURL                          string   `json:"authorization_endpoint"`
+	TokenURL                         string   `json:"token_endpoint"`
+	JWKSURI                          string   `json:"jwks_uri"`
+	UserInfoURL                      string   `json:"userinfo_endpoint"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
 }
 
 // OIDCProvider defines the interface for OIDC providers
 type OIDCProvider interface {
-  // GetOAuth2Config returns the OAuth2 configuration
-  GetOAuth2Config() (*oauth2.Config, error)
-  // GetDiscoveryURL returns the OpenID Connect discovery URL
-  GetDiscoveryURL() string
+	// GetOAuth2Config returns the OAuth2 configuration
+	GetOAuth2Config() (*oauth2.Config, error)
+	// GetDiscoveryURL returns the OpenID Connect discovery URL
+	GetDiscoveryURL() string
 }
 
 // GoogleProvider implements OIDCProvider for Google OAuth2
 type GoogleProvider struct {
-  config *config.GoogleOIDCConfig
+	config *config.GoogleOIDCConfig
 }
 
 func NewGoogleProvider(cfg *config.GoogleOIDCConfig) *GoogleProvider {
-  return &GoogleProvider{config: cfg}
+	return &GoogleProvider{config: cfg}
 }
 
 func (p *GoogleProvider) GetOAuth2Config() (*oauth2.Config, error) {
-  bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to read client credentials file")
-  }
+	bytes, err := os.ReadFile(p.config.ClientCredentialsFile)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read client credentials file")
+	}
 
-  config, err := google.ConfigFromJSON(bytes, "openid", "email")
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
-  }
-  return config, nil
+	config, err := google.ConfigFromJSON(bytes, "openid", "email")
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create OAuth2 config")
+	}
+	return config, nil
 }
 
 func (p *GoogleProvider) GetDiscoveryURL() string {
-  return p.config.GetDiscoveryURL()
+	return p.config.GetDiscoveryURL()
 }
 
 func (p *GoogleProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-  hd, ok := claims["hd"].(string)
-  if !ok {
-    return errors.New("missing hosted domain claim")
-  }
-  if hd != "" {
-    if !slices.Contains(allowedDomains, hd) {
-      return fmt.Errorf("hosted domain %v not in allowed domains", hd)
-    }
-  } else {
-    return errors.New("missing hosted domain claim")
-  }
-  return nil
+	hd, ok := claims["hd"].(string)
+	if !ok {
+		return errors.New("missing hosted domain claim")
+	}
+	if hd != "" {
+		if !slices.Contains(allowedDomains, hd) {
+			return fmt.Errorf("hosted domain %v not in allowed domains", hd)
+		}
+	} else {
+		return errors.New("missing hosted domain claim")
+	}
+	return nil
 }
 
 // GenericProvider implements OIDCProvider for generic OIDC providers
 type GenericProvider struct {
-  config *config.GenericOIDCConfig
+	config *config.GenericOIDCConfig
 }
 
 func NewGenericProvider(cfg *config.GenericOIDCConfig) *GenericProvider {
-  return &GenericProvider{config: cfg}
+	return &GenericProvider{config: cfg}
 }
 
 func (p *GenericProvider) GetOAuth2Config() (*oauth2.Config, error) {
-  return &oauth2.Config{
-    ClientID:     p.config.ClientID,
-    ClientSecret: p.config.ClientSecret,
-    RedirectURL:  p.config.RedirectURL,
-    Scopes:       p.config.Scopes,
-  }, nil
+	return &oauth2.Config{
+		ClientID:     p.config.ClientID,
+		ClientSecret: p.config.ClientSecret,
+		RedirectURL:  p.config.RedirectURL,
+		Scopes:       p.config.Scopes,
+	}, nil
 }
 
 func (p *GenericProvider) GetDiscoveryURL() string {
-  return p.config.GetDiscoveryURL()
+	return p.config.GetDiscoveryURL()
 }
 
 func (p *GenericProvider) ValidateDomainClaims(claims jwt.MapClaims, allowedDomains []string) error {
-  email, ok := claims["email"].(string)
-  if !ok {
-    return errors.New("missing email claim")
-  }
+	email, ok := claims["email"].(string)
+	if !ok {
+		return errors.New("missing email claim")
+	}
 
-  if email == "" {
-    return errors.New("empty email claim")
-  }
+	if email == "" {
+		return errors.New("empty email claim")
+	}
 
-  parts := strings.Split(email, "@")
-  if len(parts) != 2 {
-    return errors.New("invalid email format")
-  }
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 {
+		return errors.New("invalid email format")
+	}
 
-  emailDomain := parts[1]
-  if !slices.Contains(allowedDomains, emailDomain) {
-    return fmt.Errorf("email domain not in allowed domains: %s", email)
-  }
+	emailDomain := parts[1]
+	if !slices.Contains(allowedDomains, emailDomain) {
+		return fmt.Errorf("email domain not in allowed domains: %s", email)
+	}
 
-  return nil
+	return nil
 }
 
 // AuthMux wraps http.ServeMux to add protected route handling
 type AuthMux struct {
-  mux            *http.ServeMux
-  authMiddleware func(http.Handler) http.Handler
-  serverConfig   *config.AssistantServerConfig
+	mux            *http.ServeMux
+	authMiddleware func(http.Handler) http.Handler
+	serverConfig   *config.AssistantServerConfig
 }
 
 // NewAuthMux creates a new AuthMux
 func NewAuthMux(serverConfig *config.AssistantServerConfig) (*AuthMux, error) {
-  mux := http.NewServeMux()
+	mux := http.NewServeMux()
 
-  // Create auth middleware if OIDC is configured
-  var authMiddleware func(http.Handler) http.Handler
-  if serverConfig != nil && serverConfig.OIDC != nil {
-    middleware, err := NewAuthMiddleware(serverConfig.OIDC)
-    if err != nil {
-      return nil, errors.Wrapf(err, "Failed to create auth middleware")
-    }
-    authMiddleware = middleware
-  } else {
-    // No-op middleware if OIDC is not configured
-    authMiddleware = func(next http.Handler) http.Handler {
-      return next
-    }
-  }
+	// Create auth middleware if OIDC is configured
+	var authMiddleware func(http.Handler) http.Handler
+	if serverConfig != nil && serverConfig.OIDC != nil {
+		middleware, err := NewAuthMiddleware(serverConfig.OIDC)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to create auth middleware")
+		}
+		authMiddleware = middleware
+	} else {
+		// No-op middleware if OIDC is not configured
+		authMiddleware = func(next http.Handler) http.Handler {
+			return next
+		}
+	}
 
-  return &AuthMux{
-    mux:            mux,
-    authMiddleware: authMiddleware,
-    serverConfig:   serverConfig,
-  }, nil
+	return &AuthMux{
+		mux:            mux,
+		authMiddleware: authMiddleware,
+		serverConfig:   serverConfig,
+	}, nil
 }
 
 // Handle registers a handler for the given pattern
 func (p *AuthMux) Handle(pattern string, handler http.Handler) {
-  p.mux.Handle(pattern, handler)
+	p.mux.Handle(pattern, handler)
 }
 
 // HandleFunc registers a handler function for the given pattern
 func (p *AuthMux) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-  p.mux.HandleFunc(pattern, handler)
+	p.mux.HandleFunc(pattern, handler)
 }
 
 // HandleProtected registers a protected handler for the given pattern
 func (p *AuthMux) HandleProtected(pattern string, handler http.Handler, checker iam.Checker, role string) {
-  // Apply CORS if origins are configured
-  if len(p.serverConfig.CorsOrigins) > 0 {
-    c := cors.New(cors.Options{
-      AllowedOrigins: p.serverConfig.CorsOrigins,
-      AllowedMethods: connectcors.AllowedMethods(),
-      AllowedHeaders: connectcors.AllowedHeaders(),
-      ExposedHeaders: connectcors.ExposedHeaders(),
-      MaxAge:         7200, // 2 hours in seconds
-    })
-    handler = c.Handler(handler)
-  }
+	// Apply CORS if origins are configured
+	if len(p.serverConfig.CorsOrigins) > 0 {
+		c := cors.New(cors.Options{
+			AllowedOrigins: p.serverConfig.CorsOrigins,
+			AllowedMethods: connectcors.AllowedMethods(),
+			AllowedHeaders: connectcors.AllowedHeaders(),
+			ExposedHeaders: connectcors.ExposedHeaders(),
+			MaxAge:         7200, // 2 hours in seconds
+		})
+		handler = c.Handler(handler)
+	}
 
-  // We need to create a new Auth middleware that will apply the IAM checks specific to this handler
-  iamChecker := func(next http.Handler) http.Handler {
-    return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// We need to create a new Auth middleware that will apply the IAM checks specific to this handler
+	iamChecker := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-      log := logs.FromContext(r.Context())
-      idToken := getIDToken(r.Context())
-      if idToken == nil {
-        log.Info("Unauthorized: No session")
-        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-        return
-      }
+			log := logs.FromContext(r.Context())
+			idToken := getIDToken(r.Context())
+			if idToken == nil {
+				log.Info("Unauthorized: No session")
+				http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
+				return
+			}
 
-      claims, ok := idToken.Claims.(jwt.MapClaims)
-      if !ok {
-        log.Info("Unauthorized invalid claims")
-        http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
-        return
-      }
+			claims, ok := idToken.Claims.(jwt.MapClaims)
+			if !ok {
+				log.Info("Unauthorized invalid claims")
+				http.Error(w, "Unauthorized: Invalid token claims", http.StatusUnauthorized)
+				return
+			}
 
-      email, ok := claims["email"].(string)
-      if !ok {
-        log.Info("Unauthorized: Missing email claim")
-        http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
-        return
-      }
+			email, ok := claims["email"].(string)
+			if !ok {
+				log.Info("Unauthorized: Missing email claim")
+				http.Error(w, "Unauthorized: Missing email claim", http.StatusUnauthorized)
+				return
+			}
 
-      if !checker.Check(email, role) {
-        log.Info("Unauthorized", "user", email, "role", role)
-        http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
-        return
-      }
+			if !checker.Check(email, role) {
+				log.Info("Unauthorized", "user", email, "role", role)
+				http.Error(w, fmt.Sprintf("Forbidden: user %s doesn't have role %s", email, role), http.StatusForbidden)
+				return
+			}
 
-      // Get the IDToken from the context
-      next.ServeHTTP(w, r)
-    })
-  }
+			// Get the IDToken from the context
+			next.ServeHTTP(w, r)
+		})
+	}
 
-  // Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
-  p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
+	// Create a chain: check the IDToken is valid -> Apply AuthZ -> call the handler
+	p.mux.Handle(pattern, p.authMiddleware(iamChecker(handler)))
 }
 
 // HandleProtectedFunc registers a protected handler function for the given pattern
 func (p *AuthMux) HandleProtectedFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
-  p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
+	p.mux.Handle(pattern, p.authMiddleware(http.HandlerFunc(handler)))
 }
 
 // ServeHTTP implements http.Handler
 func (p *AuthMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-  p.mux.ServeHTTP(w, r)
+	p.mux.ServeHTTP(w, r)
 }
 
 // getIDToken retrieves the ID token from the context if there is one or nil
 func getIDToken(ctx context.Context) *jwt.Token {
-  idToken := ctx.Value(IDTokenKey)
-  if idToken == nil {
-    return nil
-  }
-  token, ok := idToken.(*jwt.Token)
-  if !ok {
-    log := zapr.NewLogger(zap.L())
-    log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
-    return nil
-  }
-  return token
+	idToken := ctx.Value(IDTokenKey)
+	if idToken == nil {
+		return nil
+	}
+	token, ok := idToken.(*jwt.Token)
+	if !ok {
+		log := zapr.NewLogger(zap.L())
+		log.Error(errors.New("ID token is not of type *jwt.Token"), "invalid ID token")
+		return nil
+	}
+	return token
 }

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -1,703 +1,702 @@
 package server
 
 import (
-  "crypto/rand"
-  "crypto/rsa"
-  "encoding/base64"
-  "encoding/json"
-  "io"
-  "math/big"
-  "net/http"
-  "net/http/httptest"
-  "net/url"
-  "testing"
-  "time"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
 
-  "github.com/pkg/errors"
+	"github.com/pkg/errors"
 
-  "github.com/golang-jwt/jwt/v5"
-  "github.com/jlewi/cloud-assistant/app/pkg/config"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jlewi/cloud-assistant/app/pkg/config"
 )
 
 func TestStateManager(t *testing.T) {
-  sm := newStateManager(6 * time.Second)
+	sm := newStateManager(6 * time.Second)
 
-  // Test state generation
-  state, err := sm.generateState()
-  if err != nil {
-    t.Fatalf("Failed to generate state: %v", err)
-  }
-  if state == "" {
-    t.Error("Generated state is empty")
-  }
+	// Test state generation
+	state, err := sm.generateState()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+	if state == "" {
+		t.Error("Generated state is empty")
+	}
 
-  // Test state validation
-  if !sm.validateState(state) {
-    t.Error("Valid state was not accepted")
-  }
-  if sm.validateState(state) {
-    t.Error("State was accepted twice")
-  }
+	// Test state validation
+	if !sm.validateState(state) {
+		t.Error("Valid state was not accepted")
+	}
+	if sm.validateState(state) {
+		t.Error("State was accepted twice")
+	}
 
-  // Test state expiration
-  state, err = sm.generateState()
-  if err != nil {
-    t.Fatalf("Failed to generate state: %v", err)
-  }
-  time.Sleep(sm.stateExpiration + time.Second)
-  if sm.validateState(state) {
-    t.Error("Expired state was accepted")
-  }
+	// Test state expiration
+	state, err = sm.generateState()
+	if err != nil {
+		t.Fatalf("Failed to generate state: %v", err)
+	}
+	time.Sleep(sm.stateExpiration + time.Second)
+	if sm.validateState(state) {
+		t.Error("Expired state was accepted")
+	}
 }
 
 func TestOIDC_NewOIDC(t *testing.T) {
-  // Test with nil config
-  oidc, err := newOIDC(nil)
-  if err != nil {
-    t.Errorf("Expected no error with nil config, got %v", err)
-  }
-  if oidc != nil {
-    t.Error("Expected nil OIDC with nil config")
-  }
+	// Test with nil config
+	oidc, err := newOIDC(nil)
+	if err != nil {
+		t.Errorf("Expected no error with nil config, got %v", err)
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with nil config")
+	}
 
-  // Test with nil Google config
-  cfg := &config.OIDCConfig{}
-  oidc, err = newOIDC(cfg)
-  if err != nil {
-    t.Errorf("Expected no error with nil Google config, got %v", err)
-  }
-  if oidc != nil {
-    t.Error("Expected nil OIDC with nil Google config")
-  }
+	// Test with nil Google config
+	cfg := &config.OIDCConfig{}
+	oidc, err = newOIDC(cfg)
+	if err != nil {
+		t.Errorf("Expected no error with nil Google config, got %v", err)
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with nil Google config")
+	}
 
-  // Test with invalid config
-  cfg.Google = &config.GoogleOIDCConfig{
-    ClientCredentialsFile: "nonexistent.json",
-  }
-  oidc, err = newOIDC(cfg)
-  if err == nil {
-    t.Error("Expected error with invalid config")
-  }
-  if oidc != nil {
-    t.Error("Expected nil OIDC with invalid config")
-  }
+	// Test with invalid config
+	cfg.Google = &config.GoogleOIDCConfig{
+		ClientCredentialsFile: "nonexistent.json",
+	}
+	oidc, err = newOIDC(cfg)
+	if err == nil {
+		t.Error("Expected error with invalid config")
+	}
+	if oidc != nil {
+		t.Error("Expected nil OIDC with invalid config")
+	}
 }
 
 func TestOIDC_Handlers(t *testing.T) {
-  // Create a test OIDC instance
-  cfg := &config.OIDCConfig{
-    Google: &config.GoogleOIDCConfig{
-      ClientCredentialsFile: "testdata/google-client-dummy.json",
-      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-    },
-  }
-  oidc, err := newOIDC(cfg)
-  if err != nil {
-    t.Fatalf("Failed to create OIDC instance: %v", err)
-  }
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
+	oidc, err := newOIDC(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create OIDC instance: %v", err)
+	}
 
-  t.Run("LoginHandler", func(t *testing.T) {
-    // Create a test request
-    req := httptest.NewRequest("GET", "/oidc/login", nil)
-    w := httptest.NewRecorder()
+	t.Run("LoginHandler", func(t *testing.T) {
+		// Create a test request
+		req := httptest.NewRequest("GET", "/oidc/login", nil)
+		w := httptest.NewRecorder()
 
-    // Call the handler
-    oidc.loginHandler(w, req)
+		// Call the handler
+		oidc.loginHandler(w, req)
 
-    // Check the response
-    resp := w.Result()
-    if resp.StatusCode != http.StatusFound {
-      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-    }
+		// Check the response
+		resp := w.Result()
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+		}
 
-    // Parse the redirect URL
-    redirectURL, err := url.Parse(resp.Header.Get("Location"))
-    if err != nil {
-      t.Fatalf("Failed to parse redirect URL: %v", err)
-    }
+		// Parse the redirect URL
+		redirectURL, err := url.Parse(resp.Header.Get("Location"))
+		if err != nil {
+			t.Fatalf("Failed to parse redirect URL: %v", err)
+		}
 
-    // Verify the URL contains required parameters
-    if redirectURL.Host != "accounts.google.com" {
-      t.Errorf("Expected host accounts.google.com, got %s", redirectURL.Host)
-    }
-    if clientID := redirectURL.Query().Get("client_id"); clientID != "dummy-client-id" {
-      t.Errorf("Expected client_id dummy-client-id, got %s", clientID)
-    }
-    if state := redirectURL.Query().Get("state"); state == "" {
-      t.Error("Expected non-empty state parameter")
-    }
-  })
+		// Verify the URL contains required parameters
+		if redirectURL.Host != "accounts.google.com" {
+			t.Errorf("Expected host accounts.google.com, got %s", redirectURL.Host)
+		}
+		if clientID := redirectURL.Query().Get("client_id"); clientID != "dummy-client-id" {
+			t.Errorf("Expected client_id dummy-client-id, got %s", clientID)
+		}
+		if state := redirectURL.Query().Get("state"); state == "" {
+			t.Error("Expected non-empty state parameter")
+		}
+	})
 
-  t.Run("CallbackHandler", func(t *testing.T) {
-    // Generate a valid state
-    state, err := oidc.state.generateState()
-    if err != nil {
-      t.Fatalf("Failed to generate state: %v", err)
-    }
+	t.Run("CallbackHandler", func(t *testing.T) {
+		// Generate a valid state
+		state, err := oidc.state.generateState()
+		if err != nil {
+			t.Fatalf("Failed to generate state: %v", err)
+		}
 
-    // Create a test request with invalid state
-    req := httptest.NewRequest("GET", "/oidc/callback?state=invalid&code=test-code", nil)
-    w := httptest.NewRecorder()
-    oidc.callbackHandler(w, req)
-    resp := w.Result()
-    if resp.StatusCode != http.StatusFound {
-      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-      return
-    }
+		// Create a test request with invalid state
+		req := httptest.NewRequest("GET", "/oidc/callback?state=invalid&code=test-code", nil)
+		w := httptest.NewRecorder()
+		oidc.callbackHandler(w, req)
+		resp := w.Result()
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+			return
+		}
 
-    location := resp.Header.Get("Location")
-    expectedLocation := "/login?error=invalid_state&error_description=Invalid+state+parameter"
-    if location != expectedLocation {
-      t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
-    }
+		location := resp.Header.Get("Location")
+		expectedLocation := "/login?error=invalid_state&error_description=Invalid+state+parameter"
+		if location != expectedLocation {
+			t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
+		}
 
-    // Create a test request with valid state but no code
-    req = httptest.NewRequest("GET", "/oidc/callback?state="+state, nil)
-    w = httptest.NewRecorder()
-    oidc.callbackHandler(w, req)
-    resp = w.Result()
-    if resp.StatusCode != http.StatusFound {
-      t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-      return
-    }
+		// Create a test request with valid state but no code
+		req = httptest.NewRequest("GET", "/oidc/callback?state="+state, nil)
+		w = httptest.NewRecorder()
+		oidc.callbackHandler(w, req)
+		resp = w.Result()
+		if resp.StatusCode != http.StatusFound {
+			t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+			return
+		}
 
-    location = resp.Header.Get("Location")
-    expectedLocation = "/login?error=token_exchange_failed&error_description=Failed+to+exchange+code+for+token"
-    if location != expectedLocation {
-      t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
-    }
-  })
+		location = resp.Header.Get("Location")
+		expectedLocation = "/login?error=token_exchange_failed&error_description=Failed+to+exchange+code+for+token"
+		if location != expectedLocation {
+			t.Errorf("Expected Location header %q, got %q", expectedLocation, location)
+		}
+	})
 
-  t.Run("LogoutHandler", func(t *testing.T) {
-    testPaths := []string{"/oidc/logout", "/logout"}
+	t.Run("LogoutHandler", func(t *testing.T) {
+		testPaths := []string{"/oidc/logout", "/logout"}
 
-    for _, path := range testPaths {
-      t.Run(path, func(t *testing.T) {
-        // Create a test request
-        req := httptest.NewRequest("GET", path, nil)
-        w := httptest.NewRecorder()
+		for _, path := range testPaths {
+			t.Run(path, func(t *testing.T) {
+				// Create a test request
+				req := httptest.NewRequest("GET", path, nil)
+				w := httptest.NewRecorder()
 
-        // Call the handler
-        oidc.logoutHandler(w, req)
+				// Call the handler
+				oidc.logoutHandler(w, req)
 
-        // Check the response
-        resp := w.Result()
-        if resp.StatusCode != http.StatusFound {
-          t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
-        }
+				// Check the response
+				resp := w.Result()
+				if resp.StatusCode != http.StatusFound {
+					t.Errorf("Expected status %d, got %d", http.StatusFound, resp.StatusCode)
+				}
 
-        // Verify the cookie is cleared
-        cookies := resp.Cookies()
-        if len(cookies) != 1 {
-          t.Errorf("Expected 1 cookie, got %d", len(cookies))
-        }
-        cookie := cookies[0]
-        if cookie.Name != sessionCookieName {
-          t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
-        }
-        if cookie.Value != "" {
-          t.Error("Expected empty cookie value")
-        }
-        if cookie.MaxAge != -1 {
-          t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
-        }
-      })
-    }
-  })
+				// Verify the cookie is cleared
+				cookies := resp.Cookies()
+				if len(cookies) != 1 {
+					t.Errorf("Expected 1 cookie, got %d", len(cookies))
+				}
+				cookie := cookies[0]
+				if cookie.Name != sessionCookieName {
+					t.Errorf("Expected cookie name %s, got %s", sessionCookieName, cookie.Name)
+				}
+				if cookie.Value != "" {
+					t.Error("Expected empty cookie value")
+				}
+				if cookie.MaxAge != -1 {
+					t.Errorf("Expected MaxAge -1, got %d", cookie.MaxAge)
+				}
+			})
+		}
+	})
 }
 
 func TestOIDC_DownloadJWKS(t *testing.T) {
-  // Create a test server to mock the JWKS endpoint
-  ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    // Create a test RSA key
-    key := &rsa.PublicKey{
-      N: big.NewInt(12345),
-      E: 65537,
-    }
+	// Create a test server to mock the JWKS endpoint
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Create a test RSA key
+		key := &rsa.PublicKey{
+			N: big.NewInt(12345),
+			E: 65537,
+		}
 
-    // Create a test JWKS response
-    jwks := &jwks{
-      Keys: []jwksKey{
-        {
-          Kty: "RSA",
-          Alg: "RS256",
-          Use: "sig",
-          Kid: "test-key",
-          N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
-          E:   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
-        },
-      },
-    }
+		// Create a test JWKS response
+		jwks := &jwks{
+			Keys: []jwksKey{
+				{
+					Kty: "RSA",
+					Alg: "RS256",
+					Use: "sig",
+					Kid: "test-key",
+					N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+					E:   base64.RawURLEncoding.EncodeToString([]byte{1, 0, 1}),
+				},
+			},
+		}
 
-    if err := json.NewEncoder(w).Encode(jwks); err != nil {
-      http.Error(w, "failed to encode response", http.StatusInternalServerError)
-      return
-    }
-  }))
-  defer ts.Close()
+		if err := json.NewEncoder(w).Encode(jwks); err != nil {
+			http.Error(w, "failed to encode response", http.StatusInternalServerError)
+			return
+		}
+	}))
+	defer ts.Close()
 
-  // Create a test OIDC instance
-  cfg := &config.OIDCConfig{
-    Google: &config.GoogleOIDCConfig{
-      ClientCredentialsFile: "testdata/google-client-dummy.json",
-      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-    },
-  }
-  oidc, err := newOIDC(cfg)
-  if err != nil {
-    t.Fatalf("Failed to create OIDC instance: %v", err)
-  }
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
+	oidc, err := newOIDC(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create OIDC instance: %v", err)
+	}
 
-  // Override the discovery document with our test server URL
-  oidc.discovery.JWKSURI = ts.URL
+	// Override the discovery document with our test server URL
+	oidc.discovery.JWKSURI = ts.URL
 
-  // Download the JWKS
-  err = oidc.downloadJWKS()
-  if err != nil {
-    t.Fatalf("Failed to download JWKS: %v", err)
-  }
+	// Download the JWKS
+	err = oidc.downloadJWKS()
+	if err != nil {
+		t.Fatalf("Failed to download JWKS: %v", err)
+	}
 
-  // Verify the public key was stored
-  if oidc.publicKeys["test-key"] == nil {
-    t.Error("Public key was not stored")
-  }
+	// Verify the public key was stored
+	if oidc.publicKeys["test-key"] == nil {
+		t.Error("Public key was not stored")
+	}
 }
 
 // TestIDP is an IDP that we can use for testing.
 // It can produce OIDC signed OIDC tokens that we can use to verify auth is working.
 
 type TestIDP struct {
-  privateKey *rsa.PrivateKey
-  oidc       *OIDC
-  oidcCfg    *config.OIDCConfig
+	privateKey *rsa.PrivateKey
+	oidc       *OIDC
+	oidcCfg    *config.OIDCConfig
 }
 
 func NewTestIDP() (*TestIDP, error) {
-  // Create a test RSA key
-  privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to generate RSA key")
-  }
+	// Create a test RSA key
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to generate RSA key")
+	}
 
-  // Create a test OIDC instance
-  cfg := &config.OIDCConfig{
-    Google: &config.GoogleOIDCConfig{
-      ClientCredentialsFile: "testdata/google-client-dummy.json",
-      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-    },
-    Domains: []string{"example.com"},
-  }
-  oidc, err := newOIDC(cfg)
+	// Create a test OIDC instance
+	cfg := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
+	oidc, err := newOIDC(cfg)
 
-  if err != nil {
-    return nil, errors.Wrapf(err, "Failed to create OIDC instance")
-  }
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to create OIDC instance")
+	}
 
-  // Store the public key
-  oidc.publicKeys["test-key"] = &privateKey.PublicKey
+	// Store the public key
+	oidc.publicKeys["test-key"] = &privateKey.PublicKey
 
-  return &TestIDP{
-    privateKey: privateKey,
-    oidc:       oidc,
-    oidcCfg:    cfg,
-  }, nil
+	return &TestIDP{
+		privateKey: privateKey,
+		oidc:       oidc,
+		oidcCfg:    cfg,
+	}, nil
 }
 
 func (idp *TestIDP) GenerateToken(claims jwt.Claims) (string, error) {
-  token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-  token.Header["kid"] = "test-key"
-  signedToken, err := token.SignedString(idp.privateKey)
-  if err != nil {
-    return "", errors.Wrapf(err, "Failed to sign token")
-  }
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	signedToken, err := token.SignedString(idp.privateKey)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to sign token")
+	}
 
-  return signedToken, nil
+	return signedToken, nil
 }
 
 func TestOIDC_VerifyToken(t *testing.T) {
-  idp, err := NewTestIDP()
-  if err != nil {
-    t.Fatalf("Failed to create test IDP: %v", err)
-  }
+	idp, err := NewTestIDP()
+	if err != nil {
+		t.Fatalf("Failed to create test IDP: %v", err)
+	}
 
-  // Create a valid token
-  claims := jwt.MapClaims{
-    "iss": "https://accounts.google.com",
-    "aud": "dummy-client-id",
-    "exp": time.Now().Add(time.Hour).Unix(),
-    "hd":  "example.com",
-  }
+	// Create a valid token
+	claims := jwt.MapClaims{
+		"iss": "https://accounts.google.com",
+		"aud": "dummy-client-id",
+		"exp": time.Now().Add(time.Hour).Unix(),
+		"hd":  "example.com",
+	}
 
-  signedToken, err := idp.GenerateToken(claims)
-  if err != nil {
-    t.Fatalf("Failed to sign token: %v", err)
-  }
+	signedToken, err := idp.GenerateToken(claims)
+	if err != nil {
+		t.Fatalf("Failed to sign token: %v", err)
+	}
 
-  // Verify the token
-  valid, err := idp.oidc.verifyToken(signedToken)
-  if err != nil {
-    t.Errorf("Unexpected error verifying valid token: %v", err)
-  }
-  if valid == nil {
-    t.Error("Valid token was not accepted")
-  }
+	// Verify the token
+	valid, err := idp.oidc.verifyToken(signedToken)
+	if err != nil {
+		t.Errorf("Unexpected error verifying valid token: %v", err)
+	}
+	if valid == nil {
+		t.Error("Valid token was not accepted")
+	}
 
-  // Test with invalid token
-  valid, err = idp.oidc.verifyToken("invalid-token")
-  if err == nil {
-    t.Error("Expected error with invalid token")
-  }
-  if valid != nil {
-    t.Error("Invalid token was accepted")
-  }
+	// Test with invalid token
+	valid, err = idp.oidc.verifyToken("invalid-token")
+	if err == nil {
+		t.Error("Expected error with invalid token")
+	}
+	if valid != nil {
+		t.Error("Invalid token was accepted")
+	}
 
-  // Test with expired token
-  claims["exp"] = time.Now().Add(-time.Hour).Unix()
-  expiredToken, err := idp.GenerateToken(claims)
-  if err != nil {
-    t.Fatalf("Failed to sign expired token: %v", err)
-  }
+	// Test with expired token
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	expiredToken, err := idp.GenerateToken(claims)
+	if err != nil {
+		t.Fatalf("Failed to sign expired token: %v", err)
+	}
 
-  valid, err = idp.oidc.verifyToken(expiredToken)
-  if err == nil {
-    t.Error("Expected error with expired token")
-  }
-  if valid != nil {
-    t.Error("Expired token was accepted")
-  }
+	valid, err = idp.oidc.verifyToken(expiredToken)
+	if err == nil {
+		t.Error("Expected error with expired token")
+	}
+	if valid != nil {
+		t.Error("Expired token was accepted")
+	}
 }
 
 func TestOIDCProvider_Google(t *testing.T) {
-  // Create a test Google provider
-  cfg := &config.GoogleOIDCConfig{
-    ClientCredentialsFile: "testdata/google-client-dummy.json",
-    DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-  }
-  provider := NewGoogleProvider(cfg)
+	// Create a test Google provider
+	cfg := &config.GoogleOIDCConfig{
+		ClientCredentialsFile: "testdata/google-client-dummy.json",
+		DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+	}
+	provider := NewGoogleProvider(cfg)
 
-  t.Run("GetOAuth2Config", func(t *testing.T) {
-    config, err := provider.GetOAuth2Config()
-    if err != nil {
-      t.Fatalf("Failed to get OAuth2 config: %v", err)
-    }
-    if config == nil {
-      t.Error("Expected non-nil OAuth2 config")
-    }
-  })
+	t.Run("GetOAuth2Config", func(t *testing.T) {
+		config, err := provider.GetOAuth2Config()
+		if err != nil {
+			t.Fatalf("Failed to get OAuth2 config: %v", err)
+		}
+		if config == nil {
+			t.Error("Expected non-nil OAuth2 config")
+		}
+	})
 
-  t.Run("GetDiscoveryURL", func(t *testing.T) {
-    url := provider.GetDiscoveryURL()
-    if url != cfg.GetDiscoveryURL() {
-      t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
-    }
-  })
+	t.Run("GetDiscoveryURL", func(t *testing.T) {
+		url := provider.GetDiscoveryURL()
+		if url != cfg.GetDiscoveryURL() {
+			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+		}
+	})
 
-  t.Run("ValidateDomainClaims", func(t *testing.T) {
-    // Test valid domain
-    claims := jwt.MapClaims{
-      "hd": "example.com",
-    }
-    err := provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err != nil {
-      t.Errorf("Expected no error for valid domain, got %v", err)
-    }
+	t.Run("ValidateDomainClaims", func(t *testing.T) {
+		// Test valid domain
+		claims := jwt.MapClaims{
+			"hd": "example.com",
+		}
+		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err != nil {
+			t.Errorf("Expected no error for valid domain, got %v", err)
+		}
 
-    // Test invalid domain
-    err = provider.ValidateDomainClaims(claims, []string{"other.com"})
-    if err == nil {
-      t.Error("Expected error for invalid domain")
-    }
+		// Test invalid domain
+		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+		if err == nil {
+			t.Error("Expected error for invalid domain")
+		}
 
-    // Test missing hosted domain
-    claims = jwt.MapClaims{}
-    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err == nil {
-      t.Error("Expected error for missing hosted domain")
-    }
+		// Test missing hosted domain
+		claims = jwt.MapClaims{}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for missing hosted domain")
+		}
 
-    // Test empty hosted domain
-    claims = jwt.MapClaims{"hd": ""}
-    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err == nil {
-      t.Error("Expected error for empty hosted domain")
-    }
-  })
+		// Test empty hosted domain
+		claims = jwt.MapClaims{"hd": ""}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for empty hosted domain")
+		}
+	})
 }
 
 func TestOIDCProvider_Generic(t *testing.T) {
-  // Create a test Generic provider
-  cfg := &config.GenericOIDCConfig{
-    ClientID:     "test-client-id",
-    ClientSecret: "test-client-secret",
-    RedirectURL:  "http://localhost:8080/auth/callback",
-    Scopes:       []string{"openid", "email"},
-    DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
-  }
-  provider := NewGenericProvider(cfg)
+	// Create a test Generic provider
+	cfg := &config.GenericOIDCConfig{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:8080/auth/callback",
+		Scopes:       []string{"openid", "email"},
+		DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+	}
+	provider := NewGenericProvider(cfg)
 
-  t.Run("GetOAuth2Config", func(t *testing.T) {
-    config, err := provider.GetOAuth2Config()
-    if err != nil {
-      t.Fatalf("Failed to get OAuth2 config: %v", err)
-    }
-    if config == nil {
-      t.Error("Expected non-nil OAuth2 config")
-    }
-    if config != nil && config.ClientID != cfg.ClientID {
-      t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
-    }
-    if config != nil && config.ClientSecret != cfg.ClientSecret {
-      t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
-    }
-  })
+	t.Run("GetOAuth2Config", func(t *testing.T) {
+		config, err := provider.GetOAuth2Config()
+		if err != nil {
+			t.Fatalf("Failed to get OAuth2 config: %v", err)
+		}
+		if config == nil {
+			t.Error("Expected non-nil OAuth2 config")
+		}
+		if config != nil && config.ClientID != cfg.ClientID {
+			t.Errorf("Expected client ID %s, got %s", cfg.ClientID, config.ClientID)
+		}
+		if config != nil && config.ClientSecret != cfg.ClientSecret {
+			t.Errorf("Expected client secret %s, got %s", cfg.ClientSecret, config.ClientSecret)
+		}
+	})
 
-  t.Run("GetDiscoveryURL", func(t *testing.T) {
-    url := provider.GetDiscoveryURL()
-    if url != cfg.GetDiscoveryURL() {
-      t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
-    }
-  })
+	t.Run("GetDiscoveryURL", func(t *testing.T) {
+		url := provider.GetDiscoveryURL()
+		if url != cfg.GetDiscoveryURL() {
+			t.Errorf("Expected discovery URL %s, got %s", cfg.GetDiscoveryURL(), url)
+		}
+	})
 
-  t.Run("ValidateDomainClaims", func(t *testing.T) {
-    // Test valid email domain
-    claims := jwt.MapClaims{
-      "email": "user@example.com",
-    }
-    err := provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err != nil {
-      t.Errorf("Expected no error for valid email domain, got %v", err)
-    }
+	t.Run("ValidateDomainClaims", func(t *testing.T) {
+		// Test valid email domain
+		claims := jwt.MapClaims{
+			"email": "user@example.com",
+		}
+		err := provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err != nil {
+			t.Errorf("Expected no error for valid email domain, got %v", err)
+		}
 
-    // Test invalid email domain
-    err = provider.ValidateDomainClaims(claims, []string{"other.com"})
-    if err == nil {
-      t.Error("Expected error for invalid email domain")
-    }
+		// Test invalid email domain
+		err = provider.ValidateDomainClaims(claims, []string{"other.com"})
+		if err == nil {
+			t.Error("Expected error for invalid email domain")
+		}
 
-    // Test missing email
-    claims = jwt.MapClaims{}
-    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err == nil {
-      t.Error("Expected error for missing email")
-    }
+		// Test missing email
+		claims = jwt.MapClaims{}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for missing email")
+		}
 
-    // Test empty email
-    claims = jwt.MapClaims{"email": ""}
-    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err == nil {
-      t.Error("Expected error for empty email")
-    }
+		// Test empty email
+		claims = jwt.MapClaims{"email": ""}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for empty email")
+		}
 
-    // Test invalid email format
-    claims = jwt.MapClaims{"email": "invalid-email"}
-    err = provider.ValidateDomainClaims(claims, []string{"example.com"})
-    if err == nil {
-      t.Error("Expected error for invalid email format")
-    }
-  })
+		// Test invalid email format
+		claims = jwt.MapClaims{"email": "invalid-email"}
+		err = provider.ValidateDomainClaims(claims, []string{"example.com"})
+		if err == nil {
+			t.Error("Expected error for invalid email format")
+		}
+	})
 }
 
 func TestOIDC_ProviderSelection(t *testing.T) {
-  t.Run("Google Provider", func(t *testing.T) {
-    cfg := &config.OIDCConfig{
-      Google: &config.GoogleOIDCConfig{
-        ClientCredentialsFile: "testdata/google-client-dummy.json",
-        DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-      },
-    }
-    oidc, err := newOIDC(cfg)
-    if err != nil {
-      t.Fatalf("Failed to create OIDC instance: %v", err)
-    }
-    if _, ok := oidc.provider.(*GoogleProvider); !ok {
-      t.Error("Expected GoogleProvider, got different provider type")
-    }
-  })
+	t.Run("Google Provider", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Google: &config.GoogleOIDCConfig{
+				ClientCredentialsFile: "testdata/google-client-dummy.json",
+				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+			},
+		}
+		oidc, err := newOIDC(cfg)
+		if err != nil {
+			t.Fatalf("Failed to create OIDC instance: %v", err)
+		}
+		if _, ok := oidc.provider.(*GoogleProvider); !ok {
+			t.Error("Expected GoogleProvider, got different provider type")
+		}
+	})
 
-  t.Run("Generic Provider", func(t *testing.T) {
-    cfg := &config.OIDCConfig{
-      Generic: &config.GenericOIDCConfig{
-        ClientID:     "test-client-id",
-        ClientSecret: "test-client-secret",
-        RedirectURL:  "http://localhost:8080/auth/callback",
-        Scopes:       []string{"openid", "email"},
-        DiscoveryURL: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
-      },
-    }
-    oidc, err := newOIDC(cfg)
-    if err != nil {
-      t.Fatalf("Failed to create OIDC instance: %v", err)
-    }
-    if _, ok := oidc.provider.(*GenericProvider); !ok {
-      t.Error("Expected GenericProvider, got different provider type")
-    }
-  })
+	t.Run("Generic Provider", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Generic: &config.GenericOIDCConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost:8080/auth/callback",
+				Scopes:       []string{"openid", "email"},
+				DiscoveryURL: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+			},
+		}
+		oidc, err := newOIDC(cfg)
+		if err != nil {
+			t.Fatalf("Failed to create OIDC instance: %v", err)
+		}
+		if _, ok := oidc.provider.(*GenericProvider); !ok {
+			t.Error("Expected GenericProvider, got different provider type")
+		}
+	})
 
-  t.Run("Both Providers Configured", func(t *testing.T) {
-    cfg := &config.OIDCConfig{
-      Google: &config.GoogleOIDCConfig{
-        ClientCredentialsFile: "testdata/google-client-dummy.json",
-        DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-      },
-      Generic: &config.GenericOIDCConfig{
-        ClientID:     "test-client-id",
-        ClientSecret: "test-client-secret",
-        RedirectURL:  "http://localhost:8080/auth/callback",
-        Scopes:       []string{"openid", "email"},
-        DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
-      },
-    }
-    _, err := newOIDC(cfg)
-    if err == nil {
-      t.Error("Expected error when both providers are configured")
-    }
-  })
+	t.Run("Both Providers Configured", func(t *testing.T) {
+		cfg := &config.OIDCConfig{
+			Google: &config.GoogleOIDCConfig{
+				ClientCredentialsFile: "testdata/google-client-dummy.json",
+				DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+			},
+			Generic: &config.GenericOIDCConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				RedirectURL:  "http://localhost:8080/auth/callback",
+				Scopes:       []string{"openid", "email"},
+				DiscoveryURL: "https://auth.example.com/.well-known/openid-configuration",
+			},
+		}
+		_, err := newOIDC(cfg)
+		if err == nil {
+			t.Error("Expected error when both providers are configured")
+		}
+	})
 }
 
 type DenyAllChecker struct{}
 
 func (d *DenyAllChecker) Check(principal string, role string) bool {
-  return false
+	return false
 }
 
 func TestOIDC_UnauthenticatedRoutes_NoSession(t *testing.T) {
-  // This test verifies that if there is no session token the user gets back an Unuauthorized error
-  // Create test OIDC config
-  oidcConfig := &config.OIDCConfig{
-    Google: &config.GoogleOIDCConfig{
-      ClientCredentialsFile: "testdata/google-client-dummy.json",
-      DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
-    },
-  }
+	// This test verifies that if there is no session token the user gets back an Unuauthorized error
+	// Create test OIDC config
+	oidcConfig := &config.OIDCConfig{
+		Google: &config.GoogleOIDCConfig{
+			ClientCredentialsFile: "testdata/google-client-dummy.json",
+			DiscoveryURL:          "https://accounts.google.com/.well-known/openid-configuration",
+		},
+	}
 
-  // Create server config
-  serverConfig := &config.AssistantServerConfig{
-    CorsOrigins: []string{"http://localhost:3000"},
-    OIDC:        oidcConfig,
-  }
+	// Create server config
+	serverConfig := &config.AssistantServerConfig{
+		CorsOrigins: []string{"http://localhost:3000"},
+		OIDC:        oidcConfig,
+	}
 
-  // Create auth mux
-  mux, err := NewAuthMux(serverConfig)
-  if err != nil {
-    t.Fatalf("Failed to create auth mux: %v", err)
-  }
+	// Create auth mux
+	mux, err := NewAuthMux(serverConfig)
+	if err != nil {
+		t.Fatalf("Failed to create auth mux: %v", err)
+	}
 
-  // Register auth routes
-  if err := RegisterAuthRoutes(oidcConfig, mux); err != nil {
-    t.Fatalf("Failed to register auth routes: %v", err)
-  }
+	// Register auth routes
+	if err := RegisterAuthRoutes(oidcConfig, mux); err != nil {
+		t.Fatalf("Failed to register auth routes: %v", err)
+	}
 
-  // Register test routes
-  mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    w.WriteHeader(http.StatusOK)
-  }))
-  mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    w.WriteHeader(http.StatusOK)
-  }), &DenyAllChecker{}, "test-role")
+	// Register test routes
+	mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), &DenyAllChecker{}, "test-role")
 
-  // Test public route
-  req := httptest.NewRequest("GET", "/public", nil)
-  rec := httptest.NewRecorder()
-  mux.ServeHTTP(rec, req)
-  if rec.Code != http.StatusOK {
-    t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
-  }
+	// Test public route
+	req := httptest.NewRequest("GET", "/public", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, rec.Code)
+	}
 
-  // Test protected route
-  req = httptest.NewRequest("GET", "/protected", nil)
-  rec = httptest.NewRecorder()
-  mux.ServeHTTP(rec, req)
+	// Test protected route
+	req = httptest.NewRequest("GET", "/protected", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
 
-  if rec.Code != http.StatusUnauthorized {
-    t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rec.Code)
-  }
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status code %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
 
-  msg, err := io.ReadAll(rec.Body)
-  if err != nil {
-    t.Fatalf("Failed to read response body: %v", err)
-  }
+	msg, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
 
-  if string(msg) != "Unauthorized: No valid session\n" {
-    t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
-  }
+	if string(msg) != "Unauthorized: No valid session\n" {
+		t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
+	}
 }
 
 func TestOIDC_AccessForbidden(t *testing.T) {
-  // This test verifies that if there is a session token but the user is denied by the IAMPolicy they get
-  // a forbidden error
-  idp, err := NewTestIDP()
-  if err != nil {
-    t.Fatalf("Failed to create test IDP: %v", err)
-  }
+	// This test verifies that if there is a session token but the user is denied by the IAMPolicy they get
+	// a forbidden error
+	idp, err := NewTestIDP()
+	if err != nil {
+		t.Fatalf("Failed to create test IDP: %v", err)
+	}
 
-  // Create server config
-  serverConfig := &config.AssistantServerConfig{
-    CorsOrigins: []string{"http://localhost:3000"},
-    OIDC:        idp.oidcCfg,
-  }
+	// Create server config
+	serverConfig := &config.AssistantServerConfig{
+		CorsOrigins: []string{"http://localhost:3000"},
+		OIDC:        idp.oidcCfg,
+	}
 
-  // Create auth mux
-  mux, err := NewAuthMux(serverConfig)
-  if err != nil {
-    t.Fatalf("Failed to create auth mux: %v", err)
-  }
-  // This is a bit of a hack to allow us to inject our test IDP.
-  authMiddleWare, err := newAuthMiddlewareForOIDC(idp.oidc)
-  if err != nil {
-    t.Fatalf("Failed to create auth middleware: %v", err)
-  }
-  mux.authMiddleware = authMiddleWare
-  if err != nil {
-    t.Fatalf("Failed to create auth mux: %v", err)
-  }
+	// Create auth mux
+	mux, err := NewAuthMux(serverConfig)
+	if err != nil {
+		t.Fatalf("Failed to create auth mux: %v", err)
+	}
+	// This is a bit of a hack to allow us to inject our test IDP.
+	authMiddleWare, err := newAuthMiddlewareForOIDC(idp.oidc)
+	if err != nil {
+		t.Fatalf("Failed to create auth middleware: %v", err)
+	}
+	mux.authMiddleware = authMiddleWare
+	if err != nil {
+		t.Fatalf("Failed to create auth mux: %v", err)
+	}
 
-  // Register auth routes
-  if err := RegisterAuthRoutes(idp.oidcCfg, mux); err != nil {
-    t.Fatalf("Failed to register auth routes: %v", err)
-  }
+	// Register auth routes
+	if err := RegisterAuthRoutes(idp.oidcCfg, mux); err != nil {
+		t.Fatalf("Failed to register auth routes: %v", err)
+	}
 
-  // Register test routes
-  mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    w.WriteHeader(http.StatusOK)
-  }))
+	// Register test routes
+	mux.Handle("/public", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
 
-  // We use a DenyAll to make sure we get back unauthorized
-  mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-    w.WriteHeader(http.StatusOK)
-  }), &DenyAllChecker{}, "test-role")
+	// We use a DenyAll to make sure we get back unauthorized
+	mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), &DenyAllChecker{}, "test-role")
 
-  signedToken, err := idp.GenerateToken(jwt.MapClaims{
-    "iss":   "https://accounts.google.com",
-    "aud":   "dummy-client-id",
-    "exp":   time.Now().Add(time.Hour).Unix(),
-    "hd":    "example.com",
-    "email": "john@acme.com",
-  })
+	signedToken, err := idp.GenerateToken(jwt.MapClaims{
+		"iss":   "https://accounts.google.com",
+		"aud":   "dummy-client-id",
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"hd":    "example.com",
+		"email": "john@acme.com",
+	})
 
-  if err != nil {
-    t.Fatalf("Failed to generate token: %v", err)
-  }
+	if err != nil {
+		t.Fatalf("Failed to generate token: %v", err)
+	}
 
-  sessionCookie := &http.Cookie{
-    Name:  sessionCookieName,
-    Value: signedToken,
-  }
+	sessionCookie := &http.Cookie{
+		Name:  sessionCookieName,
+		Value: signedToken,
+	}
 
-  // Test protected route
-  req := httptest.NewRequest("GET", "/protected", nil)
-  rec := httptest.NewRecorder()
-  req.AddCookie(sessionCookie)
-  mux.ServeHTTP(rec, req)
-  if rec.Code != http.StatusForbidden {
-    t.Errorf("Expected status code %d, got %d", http.StatusForbidden, rec.Code)
-  }
+	// Test protected route
+	req := httptest.NewRequest("GET", "/protected", nil)
+	rec := httptest.NewRecorder()
+	req.AddCookie(sessionCookie)
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("Expected status code %d, got %d", http.StatusForbidden, rec.Code)
+	}
 
-  msg, err := io.ReadAll(rec.Body)
-  if err != nil {
-    t.Fatalf("Failed to read response body: %v", err)
-  }
+	msg, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body: %v", err)
+	}
 
-  if string(msg) != "Forbidden: user john@acme.com doesn't have role test-role\n" {
-    t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
-  }
+	if string(msg) != "Forbidden: user john@acme.com doesn't have role test-role\n" {
+		t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
+	}
 }

--- a/app/pkg/server/server.go
+++ b/app/pkg/server/server.go
@@ -264,13 +264,18 @@ func (s *Server) registerServices() error {
 
 	mux.HandleFunc("/trailerstest", trailersTest)
 
-	// Handle the single page app and assets unprotected
-	singlePageApp, err := s.singlePageAppHandler()
-	if err != nil {
-		return errors.Wrapf(err, "Failed to serve single page app")
+	// The single page app is currently only enabled in the agent not the runner.
+	if s.agent != nil {
+		// Handle the single page app and assets unprotected
+		log.Info("Single page app is enabled")
+		singlePageApp, err := s.singlePageAppHandler()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to serve single page app")
+		}
+		mux.Handle("/", singlePageApp)
+	} else {
+		log.Info("Single page app is disabled")
 	}
-	mux.Handle("/", singlePageApp)
-
 	s.engine = mux
 
 	return nil

--- a/docs/build-image.md
+++ b/docs/build-image.md
@@ -3,3 +3,7 @@
 ## Overview
 
 This doc covers building and pushing a development image to GHCR.
+
+```sh
+gh workflow --repo=jlewi/cloud-assistant run image.yaml --ref feature-branch
+```

--- a/docs/build-image.md
+++ b/docs/build-image.md
@@ -1,0 +1,5 @@
+# Build And Push Docker Image
+
+## Overview
+
+This doc covers building and pushing a development image to GHCR.

--- a/docs/securing-the-runner.md
+++ b/docs/securing-the-runner.md
@@ -67,10 +67,19 @@ iamPolicy:
     - role: role/agent.user
       members:
       - name: bob@acme.com
+        kind: user
     - role: role/runner.user
       members:
       - name: bob@acme.com
+        kind: user
 ```
+
+kind is either `user` or `domain`.
+
+|kind | Meaning Of Name |
+|------|----------------|
+| user | The email address of the user |
+| domain | The domain of the user. For example `acme.com` would match all users in the domain `acme.com` |
 
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,3 +33,21 @@ The server will show the error.
 ```plaintext
 2025/04/29 13:58:12 http: TLS handshake error from [::1]:57040: remote error: tls: unknown certificate
 ```
+
+### Unknown TLS Certificate
+
+If you imported your TLS Certificate into keychain and the backend is showing the error
+
+```
+2025/05/02 09:30:20 http: TLS handshake error from [::1]:49795: remote error: tls: unknown certificate
+```
+
+Try
+
+1. Deleting the certificate in keychain
+1. Reimporting the certificate
+
+It looks like if you already imported a `Cloud Assistant Certificate` into keychain, the new certificate will not
+get imported so you have to delete it first.
+
+TODO(jlewi@): What's a better solution for this?


### PR DESCRIPTION
* Add domains as supported IAMPolicy. This could be used to require login to the Agent but allow anyone to login. The advantage of this is we get information about users but can still let anyone in an organization use it.

* Disable the singlepage app in the server if the agent isn't running; i.e. if we have a runner only server