### PR TITLE
Allow auth token to be passed as Bearer

### DIFF
--- a/app/pkg/server/auth.go
+++ b/app/pkg/server/auth.go
@@ -303,18 +303,25 @@ func newAuthMiddlewareForOIDC(oidc *OIDC) (func(http.Handler) http.Handler, erro
         return
       }
 
-      // Get the session token from the cookie
-      cookie, err := r.Cookie(sessionCookieName)
-      if err != nil {
-        // No session cookie, return 401 Unauthorized
-        log.Error(err, "No session cookie found")
-        http.Error(w, "Unauthorized: No valid session", http.StatusUnauthorized)
-        return
+      var idToken string
+      // Check for Bearer token in Authorization header
+      authHeader := r.Header.Get("Authorization")
+      if strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+        idToken = strings.TrimPrefix(authHeader, authHeader[:7]) // Remove prefix
+        idToken = strings.TrimSpace(idToken)
+      } else {
+        // Fallback to session cookie
+        cookie, err := r.Cookie(sessionCookieName)
+        if err != nil {
+          // No session cookie or bearer token, return 401 Unauthorized
+          log.Error(err, "No session cookie or bearer token found")
+          http.Error(w, "Unauthorized: No valid session or token", http.StatusUnauthorized)
+          return
+        }
+        idToken = cookie.Value
       }
 
       // Verify the token by parsing and validating the JWT
-      idToken := cookie.Value
-
       token, err := oidc.verifyToken(idToken)
       if token == nil {
         log.Error(err, "Token validation failed")
@@ -382,7 +389,7 @@ func (o *OIDC) callbackHandler(w http.ResponseWriter, r *http.Request) {
     Name:     sessionCookieName,
     Value:    idToken,
     Path:     "/",
-    HttpOnly: true,
+    HttpOnly: false,
     Secure:   true,
     SameSite: http.SameSiteLaxMode,
   })

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -734,7 +734,7 @@ func TestOIDC_TokenHierarchy(t *testing.T) {
   // Register a protected route that returns 200 OK
   mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
     w.WriteHeader(http.StatusOK)
-    w.Write([]byte("OK"))
+    _, _ = w.Write([]byte("OK"))
   }), &DenyAllChecker{}, "test-role")
 
   // Generate three tokens for clarity

--- a/app/pkg/server/auth_test.go
+++ b/app/pkg/server/auth_test.go
@@ -701,3 +701,98 @@ func TestOIDC_AccessForbidden(t *testing.T) {
     t.Errorf("Expected response body 'Unauthorized', got '%s'", msg)
   }
 }
+
+func TestOIDC_TokenHierarchy(t *testing.T) {
+  idp, err := NewTestIDP()
+  if err != nil {
+    t.Fatalf("Failed to create test IDP: %v", err)
+  }
+
+  // Create server config
+  serverConfig := &config.AssistantServerConfig{
+    CorsOrigins: []string{"http://localhost:3000"},
+    OIDC:        idp.oidcCfg,
+  }
+
+  // Create auth mux
+  mux, err := NewAuthMux(serverConfig)
+  if err != nil {
+    t.Fatalf("Failed to create auth mux: %v", err)
+  }
+  // Inject our test OIDC
+  authMiddleware, err := newAuthMiddlewareForOIDC(idp.oidc)
+  if err != nil {
+    t.Fatalf("Failed to create auth middleware: %v", err)
+  }
+  mux.authMiddleware = authMiddleware
+
+  // Register auth routes
+  if err := RegisterAuthRoutes(idp.oidcCfg, mux); err != nil {
+    t.Fatalf("Failed to register auth routes: %v", err)
+  }
+
+  // Register a protected route that returns 200 OK
+  mux.HandleProtected("/protected", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(http.StatusOK)
+    w.Write([]byte("OK"))
+  }), &DenyAllChecker{}, "test-role")
+
+  // Generate three tokens for clarity
+  claims := jwt.MapClaims{
+    "iss":   "https://accounts.google.com",
+    "aud":   "dummy-client-id",
+    "exp":   time.Now().Add(time.Hour).Unix(),
+    "hd":    "example.com",
+    "email": "john@acme.com",
+  }
+  token, err := idp.GenerateToken(claims)
+  if err != nil {
+    t.Fatalf("Failed to generate token: %v", err)
+  }
+
+  const AuthedButForbidden = http.StatusForbidden
+
+  t.Run("Header takes precedence over query and cookie", func(t *testing.T) {
+    authParam := url.QueryEscape("authorization=Bearer invalid")
+    req := httptest.NewRequest("GET", "/protected?"+authParam, nil)
+    req.Header.Set("Authorization", "Bearer "+token)
+    req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "invalid"})
+    rec := httptest.NewRecorder()
+    mux.ServeHTTP(rec, req)
+    if rec.Code != AuthedButForbidden {
+      t.Errorf("Expected status %d, got %d", AuthedButForbidden, rec.Code)
+    }
+  })
+
+  t.Run("Query param takes precedence over cookie", func(t *testing.T) {
+    params := url.Values{}
+    params.Set("authorization", "Bearer "+token)
+    req := httptest.NewRequest("GET", "/protected?"+params.Encode(), nil)
+    req.Header.Set("Authorization", "")
+    req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "invalid"})
+    rec := httptest.NewRecorder()
+    mux.ServeHTTP(rec, req)
+    if rec.Code != AuthedButForbidden {
+      t.Errorf("Expected status %d, got %d", AuthedButForbidden, rec.Code)
+    }
+  })
+
+  t.Run("Cookie is used if no header or query param", func(t *testing.T) {
+    req := httptest.NewRequest("GET", "/protected", nil)
+    req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: token})
+    rec := httptest.NewRecorder()
+    mux.ServeHTTP(rec, req)
+    if rec.Code != AuthedButForbidden {
+      t.Errorf("Expected status %d, got %d", AuthedButForbidden, rec.Code)
+    }
+  })
+
+  t.Run("Unauthorized if no token anywhere", func(t *testing.T) {
+    req := httptest.NewRequest("GET", "/protected", nil)
+    rec := httptest.NewRecorder()
+    mux.ServeHTTP(rec, req)
+    if rec.Code != http.StatusUnauthorized {
+      t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+    }
+  })
+}

--- a/web/src/components/Runme/Console.tsx
+++ b/web/src/components/Runme/Console.tsx
@@ -22,6 +22,7 @@ import {
   SocketResponse,
   SocketResponseSchema,
 } from '../../gen/es/cassie/sockets_pb'
+import { getTokenValue } from '../../token'
 import './renderers/client'
 // @ts-expect-error because the webcomponents are not typed
 import { ClientMessages, setContext } from './renderers/client'
@@ -379,6 +380,10 @@ function isInViewport(element: Element) {
 
 function createWebSocket(runnerEndpoint: string): WebSocket {
   const url = new URL(runnerEndpoint)
+  const token = getTokenValue()
+  if (token) {
+    url.searchParams.set('authorization', `Bearer ${token}`)
+  }
   const ws = new WebSocket(url.toString())
 
   ws.onopen = () => {

--- a/web/src/contexts/AgentContext.tsx
+++ b/web/src/contexts/AgentContext.tsx
@@ -11,6 +11,7 @@ import { Code, ConnectError, createClient } from '@connectrpc/connect'
 import { createGrpcWebTransport } from '@connectrpc/connect-web'
 
 import * as blocks_pb from '../gen/es/cassie/blocks_pb'
+import { getTokenValue } from '../token'
 import { useSettings } from './SettingsContext'
 
 export type AgentClient = ReturnType<
@@ -66,6 +67,10 @@ function createAgentClient(baseURL: string): AgentClient {
     baseUrl: baseURL,
     interceptors: [
       (next) => (req) => {
+        const token = getTokenValue()
+        if (token) {
+          req.header.set('Authorization', `Bearer ${token}`)
+        }
         return next(req).catch((e) => {
           redirectOnUnauthError(e)
           throw e // allow caller to handle the error

--- a/web/src/token.tsx
+++ b/web/src/token.tsx
@@ -1,0 +1,9 @@
+export const SESSION_COOKIE_NAME = 'cassie-session'
+
+// Returns the value of the session token cookie, or undefined if not found
+export function getTokenValue(): string | undefined {
+  const match = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(SESSION_COOKIE_NAME + '='))
+  return match?.split('=')[1]
+}


### PR DESCRIPTION
This decouples the auth token from HTTP. In summary, here are the changes:

1. Allow cookie holding token access in JS sandbox. Keeps 12h expiry and leaves OIDC auth flow unchanged.
2. Check token presence in requests as `Authorization` header, `authorization` query param, or cookie in order.
3. Pass the token as `Authorization` header in Connect requests and query parameter (best practice) for websocket upgrades.

It'd be possible to remove the need for a cookie entirely; however, holding the token in `localStorage` instead requires more custom code with virtually no difference in functionality or security. Lemme know if you want cookies removed entirely, @jlewi.