### PR TITLE
Leverage GIT_SHA_SHORT as cache buster if set

### DIFF
--- a/app/pkg/server/assets.go
+++ b/app/pkg/server/assets.go
@@ -29,7 +29,7 @@ func getAssetFileSystem(staticAssets string) (fs.FS, error) {
 
 	// Try to use embedded assets
 	distFS, _ := fs.Sub(embeddedAssets, "dist")
-	_, err := distFS.Open("index.js")
+	_, err := distFS.Open("index.html")
 	if err == nil {
 		log.Info("Serving embedded assets")
 		return distFS, nil

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,10 @@ import { defineConfig } from 'vite'
 
 // import viteCompression from 'vite-plugin-compression'
 
+const GIT_SHA_SHORT = process.env.GIT_SHA_SHORT
+  ? `.${process.env.GIT_SHA_SHORT}`
+  : ''
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -20,9 +24,9 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: undefined,
-        entryFileNames: 'index.js',
-        chunkFileNames: 'index.js',
-        assetFileNames: '[name].[ext]',
+        entryFileNames: `index${GIT_SHA_SHORT}.js`,
+        chunkFileNames: `index${GIT_SHA_SHORT}.js`,
+        assetFileNames: `[name]${GIT_SHA_SHORT}.[ext]`,
       },
     },
   },


### PR DESCRIPTION
The idea is simple: if `GIT_SHA_SHORT` is set as per https://github.com/jlewi/cloud-assistant/blob/main/app/Makefile#L5, include it in the bundle's filenames to make sure they always result in a cache miss.