### PR TITLE
Pass along GIT_SHA_SHORT for cache busting.

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -6,7 +6,7 @@ on:
       - main
       # For testing the changes to the workflow to tag the commit and allow workflow dispatch. 
       # We can get rid of this once we are happy with the updated workflow
-      - jlewi/oidc
+      - jlewi/cache
   # Allow manual triggering
   # This allows building images from branches
   workflow_dispatch: {}
@@ -38,7 +38,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          build-args: |
+            COMMIT_SHORT_SHA=${{ env.COMMIT_SHORT_SHA }}
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:commit-${{  env.COMMIT_SHORT_SHA }}
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,17 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
     -a -o /app/cas github.com/jlewi/cloud-assistant/app
 
 FROM node:18-alpine AS builder
+# Accept the build argument
+ARG COMMIT_SHORT_SHA
+
+# Set it as an environment variable
+# This gets picked by our vit configuration and names the file index${GIT_SHA_SHORT}.js.
+# This enables cache busting; when you refresh the app you get a new version.
+# You can also tell which version of the code you are running by looking at your index.html
+ENV GIT_SHA_SHORT=$COMMIT_SHORT_SHA
+
+# Optional: print it for debug
+RUN echo "Short SHA: GIT_SHA_SHORT"
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 # TODO(jlewi): Do we still need this

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG COMMIT_SHORT_SHA
 ENV GIT_SHA_SHORT=$COMMIT_SHORT_SHA
 
 # Optional: print it for debug
-RUN echo "Short SHA: GIT_SHA_SHORT"
+RUN echo "Short SHA: ${GIT_SHA_SHORT}"
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 # TODO(jlewi): Do we still need this


### PR DESCRIPTION
* We need to pass along the GIT_GHA_SHORT the vite build process so that our index files end up being tagged with the commit.

Related to #51 