### PR TITLE
Propagate logger with traceId via IntoContext helper

### DIFF
--- a/app/pkg/ai/agent.go
+++ b/app/pkg/ai/agent.go
@@ -151,6 +151,7 @@ func (a *Agent) ProcessWithOpenAI(ctx context.Context, req *cassie.GenerateReque
 	log := logs.FromContext(ctx)
 	traceId := span.SpanContext().TraceID()
 	log = log.WithValues("traceId", traceId)
+	ctx = logs.IntoContext(ctx, log)
 	log.Info("Agent.Generate")
 
 	if (len(req.Blocks)) < 1 {

--- a/app/pkg/logs/context.go
+++ b/app/pkg/logs/context.go
@@ -17,6 +17,10 @@ func FromContext(ctx context.Context) logr.Logger {
 	return l
 }
 
+func IntoContext(ctx context.Context, l logr.Logger) context.Context {
+	return logr.NewContext(ctx, l)
+}
+
 func NewLogger() logr.Logger {
 	// We need to AllowZapFields to ensure the protobuf message is logged correctly as a json object.
 	// For that to work we need to do logr.Info("message", zap.Object("key", protoMessage))


### PR DESCRIPTION
feat: add IntoContext helper to propagate logger with traceId through context