### PR TITLE
Configure Monaco editor to not always consume mousewheel

### DIFF
--- a/web/src/components/Actions/Actions.tsx
+++ b/web/src/components/Actions/Actions.tsx
@@ -191,6 +191,9 @@ const CodeEditor = memo(
             defaultLanguage="shellscript"
             value={value}
             options={{
+              scrollbar: {
+                alwaysConsumeMouseWheel: false,
+              },
               minimap: { enabled: false },
               theme: 'vs-dark',
               wordWrap: 'wordWrapColumn',


### PR DESCRIPTION
Early testing showed improved behavior for the issue described in https://github.com/jlewi/cloud-assistant/issues/38.