### PR TITLE
Currently requiring node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
     -ldflags "${LDFLAGS}" \
     -a -o /app/cas github.com/jlewi/cloud-assistant/app
 
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 # Accept the build argument
 ARG COMMIT_SHORT_SHA
 


### PR DESCRIPTION
Node 18 throws warnings/errors since the F/E code base requires Node 20 types.

Node 20 is currently in Maintenance LTS, whereas Node 18 was EOL'd on 2025-04-30.