### PR TITLE
Refactor eval to use a single Experiment spec

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -1,6 +1,6 @@
 # A basic workflow for Go
 name: test-go
-on: [push, pull_request]
+on: [push, pull_request_target]
 defaults:
   run:
     shell: bash -ieo pipefail {0}

--- a/app/cmd/eval.go
+++ b/app/cmd/eval.go
@@ -1,23 +1,46 @@
 package cmd
 
 import (
+	"encoding/json"
+	"os"
+
 	"github.com/jlewi/cloud-assistant/app/pkg/ai"
 	"github.com/jlewi/cloud-assistant/app/pkg/application"
+	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+	"gopkg.in/yaml.v3"
 )
 
 func NewEvalCmd() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "eval <yaml-file> <target-url>",
-		Short: "Run evaluation using a YAML file and target URL",
-		Args:  cobra.ExactArgs(2),
+		Use:   "eval <yaml-file>",
+		Short: "Run evaluation using a single experiment YAML file",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			app := application.NewApp()
 			if err := app.LoadConfig(cmd); err != nil {
 				return err
 			}
-			app.Config.CloudAssistant.TargetURL = args[1]
-			_, err := ai.EvalFromYAML(args[0], app.Config.CloudAssistant)
+
+			// Read the experiment YAML file
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return err
+			}
+			var m map[string]interface{}
+			if err := yaml.Unmarshal(data, &m); err != nil {
+				return err
+			}
+			jsonBytes, err := json.Marshal(m) // use json as intermediate format
+			if err != nil {
+				return err
+			}
+			var experiment cassie.ExperimentRun
+			if err := protojson.Unmarshal(jsonBytes, &experiment); err != nil {
+				return err
+			}
+			_, err = ai.EvalFromExperimentRun(&experiment)
 			if err != nil {
 				return err
 			}

--- a/app/cmd/eval.go
+++ b/app/cmd/eval.go
@@ -36,11 +36,11 @@ func NewEvalCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			var experiment cassie.ExperimentRun
+			var experiment cassie.Experiment
 			if err := protojson.Unmarshal(jsonBytes, &experiment); err != nil {
 				return err
 			}
-			_, err = ai.EvalFromExperimentRun(&experiment)
+			_, err = ai.EvalFromExperiment(&experiment)
 			if err != nil {
 				return err
 			}

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -244,27 +244,27 @@ func runInference(input string, cassieCookie string, inferenceEndpoint string) (
 // EvalFromExperiment runs an experiment based on the Experiment config.
 func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[string]*cassie.Block, error) {
 	// Read the experiment YAML file
-	data, err := os.ReadFile(exp.GetDatasetPath())
+	data, err := os.ReadFile(exp.Spec.GetDatasetPath())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read dataset yaml file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to read dataset yaml file %q", exp.Spec.GetDatasetPath())
 	}
 	// Unmarshal YAML to generic map
 	var yamlObj interface{}
 	if err := yaml.Unmarshal(data, &yamlObj); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal dataset yaml file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to unmarshal dataset yaml file %q", exp.Spec.GetDatasetPath())
 	}
 	// Convert YAML to JSON
 	jsonData, err := json.Marshal(yamlObj)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to marshal dataset yaml to json for file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to marshal dataset yaml to json for file %q", exp.Spec.GetDatasetPath())
 	}
 	var dataset cassie.EvalDataset
 	if err := protojson.Unmarshal(jsonData, &dataset); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for dataset file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for dataset file %q", exp.Spec.GetDatasetPath())
 	}
 
 	cassieCookie := cookie["cassie-session"]
-	inferenceEndpoint := exp.GetInferenceEndpoint()
+	inferenceEndpoint := exp.Spec.GetInferenceEndpoint()
 
 	for _, sample := range dataset.Samples {
 		blocks, err := runInference(sample.InputText, cassieCookie, inferenceEndpoint)

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -246,21 +246,21 @@ func EvalFromExperimentRun(exp *cassie.ExperimentRun) (map[string]*cassie.Block,
 	// Read the experiment YAML file
 	data, err := os.ReadFile(exp.GetDatasetPath())
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read experiment dataset yaml file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to read dataset yaml file %q", exp.GetDatasetPath())
 	}
 	// Unmarshal YAML to generic map
 	var yamlObj interface{}
 	if err := yaml.Unmarshal(data, &yamlObj); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal experiment dataset yaml file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to unmarshal dataset yaml file %q", exp.GetDatasetPath())
 	}
 	// Convert YAML to JSON
 	jsonData, err := json.Marshal(yamlObj)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to marshal experiment dataset yaml to json for file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to marshal dataset yaml to json for file %q", exp.GetDatasetPath())
 	}
 	var dataset cassie.EvalDataset
 	if err := protojson.Unmarshal(jsonData, &dataset); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for experiment dataset file %q", exp.GetDatasetPath())
+		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for dataset file %q", exp.GetDatasetPath())
 	}
 
 	// Prepare config from ExperimentRun fields

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -143,7 +143,7 @@ func runInference(input string, cassieCookie string, inferenceEndpoint string) (
 
 	baseURL := inferenceEndpoint
 	if baseURL == "" {
-		return blocks, errors.New("TargetURL is not set in config")
+		return blocks, errors.New("inferenceEndpoint is not set in config")
 	}
 
 	u, err := url.Parse(baseURL)

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -242,7 +242,7 @@ func runInference(input string, cassieCookie string, inferenceEndpoint string) (
 }
 
 // EvalFromExperiment runs an experiment based on the Experiment config.
-func EvalFromExperiment(exp *cassie.Experiment) (map[string]*cassie.Block, error) {
+func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[string]*cassie.Block, error) {
 	// Read the experiment YAML file
 	data, err := os.ReadFile(exp.GetDatasetPath())
 	if err != nil {
@@ -263,8 +263,7 @@ func EvalFromExperiment(exp *cassie.Experiment) (map[string]*cassie.Block, error
 		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for dataset file %q", exp.GetDatasetPath())
 	}
 
-	// Prepare config from Experiment fields
-	cassieCookie := exp.GetCassieAuthCookie()
+	cassieCookie := cookie["cassie-session"]
 	inferenceEndpoint := exp.GetInferenceEndpoint()
 
 	for _, sample := range dataset.Samples {

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -241,8 +241,8 @@ func runInference(input string, cassieCookie string, inferenceEndpoint string) (
 	return blocks, nil
 }
 
-// EvalFromExperimentRun runs an experiment based on the ExperimentRun config.
-func EvalFromExperimentRun(exp *cassie.ExperimentRun) (map[string]*cassie.Block, error) {
+// EvalFromExperiment runs an experiment based on the Experiment config.
+func EvalFromExperiment(exp *cassie.Experiment) (map[string]*cassie.Block, error) {
 	// Read the experiment YAML file
 	data, err := os.ReadFile(exp.GetDatasetPath())
 	if err != nil {
@@ -263,7 +263,7 @@ func EvalFromExperimentRun(exp *cassie.ExperimentRun) (map[string]*cassie.Block,
 		return nil, errors.Wrapf(err, "failed to unmarshal json to proto for dataset file %q", exp.GetDatasetPath())
 	}
 
-	// Prepare config from ExperimentRun fields
+	// Prepare config from Experiment fields
 	cassieCookie := exp.GetCassieAuthCookie()
 	inferenceEndpoint := exp.GetInferenceEndpoint()
 

--- a/app/pkg/application/app.go
+++ b/app/pkg/application/app.go
@@ -41,9 +41,6 @@ func (a *App) LoadConfig(cmd *cobra.Command) error {
 		return err
 	}
 	cfg := config.GetConfig()
-	if cfg.CloudAssistant == nil {
-		return fmt.Errorf("CloudAssistant config is nil")
-	}
 	if problems := cfg.IsValid(); len(problems) > 0 {
 		_, _ = fmt.Fprintf(os.Stdout, "Invalid configuration; %s\n", strings.Join(problems, "\n"))
 		return fmt.Errorf("invalid configuration; fix the problems and then try again")

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -38,16 +38,46 @@ This document explains **Level 1 evaluations** for the AI SRE project—simple, 
 
 ## 3 — Quick Start
 
-### Build the CLI
-`make build`
+1. **Build the CLI**
 
-### Edit `config.yaml` to set your Cassie session cookie
-```
-cloudAssistant:
-  vectorStores:
-    - vs_xxxxx
-  cassieCookie: <your-cassie-session-cookie>
-```
+   ```bash
+   make build
+   ```
 
-### Run the eval against a local Cassie endpoint
-`./.build/cas eval dataset.pb http://localhost:8080`
+2. **Create a Dataset YAML**
+
+   Define the questions and assertions you want to test.  A minimal example is shown below:
+
+   ```yaml
+   samples:
+     - name: test_AKS_required_flags
+       description: Checks that every az aks command carries the --subscription and --resource-group flags.
+       inputText: What region is cluster unified-60 in?
+       assertions:
+         - name: az_aks_has_required_flag
+           type: TYPE_SHELL_REQUIRED_FLAG
+           shellRequiredFlag:
+             command: az aks
+             flags:
+               - --subscription
+               - --resource-group
+   ```
+
+3. **Create an Experiment YAML**
+
+   Point the experiment at the dataset and your Cassie backend:
+
+   ```yaml
+   name: "experiment_test"
+   dataset_path: "./dataset/dataset_test.yaml"   # path to the dataset file above
+   cassie_auth_cookie: "<your-cassie-session-cookie>" # copy from your browser
+   output_dir: "./experiments/out"             # where reports will be written
+   inference_endpoint: "http://localhost:8080" # Cassie inference service
+   ```
+
+4. **Run the evaluation**
+
+   ```bash
+   ./.build/cas eval ./dataset/experiment_test.yaml
+   ```
+

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -63,21 +63,29 @@ This document explains **Level 1 evaluations** for the AI SRE project—simple, 
                - --resource-group
    ```
 
-3. **Create an Experiment YAML**
+3. **Create a Cookie File**
 
-   Point the experiment at the dataset and your Cassie backend:
+   The cookie file should be in .env format (one key=value per line). For example:
+
+   ```env
+   cassie-session=your-cassie-session-cookie
+   another-cookie=another-value
+   ```
+
+4. **Create an Experiment YAML**
+
+   Point the experiment at the dataset and your Cassie backend.
 
    ```yaml
    name: "experiment_test"
    dataset_path: "./dataset/dataset_test.yaml"   # path to the dataset file above
-   cassie_auth_cookie: "<your-cassie-session-cookie>" # copy from your browser
    output_dir: "./experiments/out"             # where reports will be written
    inference_endpoint: "http://localhost:8080" # Cassie inference service
    ```
 
-4. **Run the evaluation**
+5. **Run the evaluation**
 
    ```bash
-   ./.build/cas eval ./dataset/experiment_test.yaml
+   ./.build/cas eval ./dataset/experiment_test.yaml --cookie-file ./path/to/cookies.env
    ```
 

--- a/protos/cassie/eval.proto
+++ b/protos/cassie/eval.proto
@@ -88,9 +88,32 @@ message EvalDataset{
 // Experiment – Configuration for running an evaluation experiment
 // -------------------------------------------------------------------------
 
+message ObjectMeta {
+  // Name of the resource, e.g. "experiment-test".
+  string name = 1;
+}
+
+message ExperimentSpec {
+  // Path to the YAML dataset to evaluate.
+  string dataset_path       = 1 [json_name = "datasetPath"];
+
+  // Directory where experiment reports will be written.
+  string output_dir         = 2 [json_name = "outputDir"];
+
+  // URL of the backend inference service to call during evaluation.
+  string inference_endpoint = 3 [json_name = "inferenceEndpoint"];
+}
+
 message Experiment {
-  string name = 1;                    // Name of the experiment, e.g. "aks_flag_eval"
-  string dataset_path = 2;            // Path to the YAML dataset to evaluate
-  string output_dir = 3;              // Directory to write experiment reports
-  string inference_endpoint = 4;      // URL of the backend inference service
+  // API version of the resource, e.g. "cloudassistant.io/v1alpha1".
+  string     api_version = 1 [json_name = "apiVersion"];
+
+  // Kind of the resource. Always "Experiment" for this CRD.
+  string     kind        = 2;
+
+  // Standard Kubernetes object metadata (name, labels, annotations, etc.).
+  ObjectMeta metadata    = 3;
+
+  // User-defined configuration for the experiment.
+  ExperimentSpec spec    = 4;
 }

--- a/protos/cassie/eval.proto
+++ b/protos/cassie/eval.proto
@@ -82,3 +82,16 @@ message EvalSample {
 message EvalDataset{
   repeated EvalSample samples = 1;
 }
+
+
+// -------------------------------------------------------------------------
+// ExperimentRun – Configuration for running an evaluation experiment
+// -------------------------------------------------------------------------
+
+message ExperimentRun {
+  string name = 1;                    // Name of the experiment, e.g. "aks_flag_eval"
+  string dataset_path = 2;            // Path to the YAML dataset to evaluate
+  string cassie_auth_cookie = 3;      // Authorization cookie for backend eval server
+  string output_dir = 4;              // Directory to write experiment reports
+  string inference_endpoint = 5;      // URL of the backend inference service
+}

--- a/protos/cassie/eval.proto
+++ b/protos/cassie/eval.proto
@@ -91,7 +91,6 @@ message EvalDataset{
 message Experiment {
   string name = 1;                    // Name of the experiment, e.g. "aks_flag_eval"
   string dataset_path = 2;            // Path to the YAML dataset to evaluate
-  string cassie_auth_cookie = 3;      // Authorization cookie for backend eval server
-  string output_dir = 4;              // Directory to write experiment reports
-  string inference_endpoint = 5;      // URL of the backend inference service
+  string output_dir = 3;              // Directory to write experiment reports
+  string inference_endpoint = 4;      // URL of the backend inference service
 }

--- a/protos/cassie/eval.proto
+++ b/protos/cassie/eval.proto
@@ -85,10 +85,10 @@ message EvalDataset{
 
 
 // -------------------------------------------------------------------------
-// ExperimentRun – Configuration for running an evaluation experiment
+// Experiment – Configuration for running an evaluation experiment
 // -------------------------------------------------------------------------
 
-message ExperimentRun {
+message Experiment {
   string name = 1;                    // Name of the experiment, e.g. "aks_flag_eval"
   string dataset_path = 2;            // Path to the YAML dataset to evaluate
   string cassie_auth_cookie = 3;      // Authorization cookie for backend eval server

--- a/protos/cassie/eval.proto
+++ b/protos/cassie/eval.proto
@@ -58,7 +58,7 @@ message Assertion {
     string file_name = 2;                         // Optional human-readable name
   }
 
-  // Asks an LLM to grade the assistant’s answer.
+  // Asks an LLM to grade the assistant's answer.
   message LLMJudge {
     string    prompt = 1;
   }

--- a/protos/gen/cassie/eval.pb.go
+++ b/protos/gen/cassie/eval.pb.go
@@ -411,9 +411,8 @@ type Experiment struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                                    // Name of the experiment, e.g. "aks_flag_eval"
 	DatasetPath       string                 `protobuf:"bytes,2,opt,name=dataset_path,json=datasetPath,proto3" json:"dataset_path,omitempty"`                   // Path to the YAML dataset to evaluate
-	CassieAuthCookie  string                 `protobuf:"bytes,3,opt,name=cassie_auth_cookie,json=cassieAuthCookie,proto3" json:"cassie_auth_cookie,omitempty"`  // Authorization cookie for backend eval server
-	OutputDir         string                 `protobuf:"bytes,4,opt,name=output_dir,json=outputDir,proto3" json:"output_dir,omitempty"`                         // Directory to write experiment reports
-	InferenceEndpoint string                 `protobuf:"bytes,5,opt,name=inference_endpoint,json=inferenceEndpoint,proto3" json:"inference_endpoint,omitempty"` // URL of the backend inference service
+	OutputDir         string                 `protobuf:"bytes,3,opt,name=output_dir,json=outputDir,proto3" json:"output_dir,omitempty"`                         // Directory to write experiment reports
+	InferenceEndpoint string                 `protobuf:"bytes,4,opt,name=inference_endpoint,json=inferenceEndpoint,proto3" json:"inference_endpoint,omitempty"` // URL of the backend inference service
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -458,13 +457,6 @@ func (x *Experiment) GetName() string {
 func (x *Experiment) GetDatasetPath() string {
 	if x != nil {
 		return x.DatasetPath
-	}
-	return ""
-}
-
-func (x *Experiment) GetCassieAuthCookie() string {
-	if x != nil {
-		return x.CassieAuthCookie
 	}
 	return ""
 }
@@ -774,15 +766,14 @@ const file_cassie_eval_proto_rawDesc = "" +
 	".AssertionR\n" +
 	"assertions\"4\n" +
 	"\vEvalDataset\x12%\n" +
-	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\xbf\x01\n" +
+	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\x91\x01\n" +
 	"\n" +
 	"Experiment\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
-	"\fdataset_path\x18\x02 \x01(\tR\vdatasetPath\x12,\n" +
-	"\x12cassie_auth_cookie\x18\x03 \x01(\tR\x10cassieAuthCookie\x12\x1d\n" +
+	"\fdataset_path\x18\x02 \x01(\tR\vdatasetPath\x12\x1d\n" +
 	"\n" +
-	"output_dir\x18\x04 \x01(\tR\toutputDir\x12-\n" +
-	"\x12inference_endpoint\x18\x05 \x01(\tR\x11inferenceEndpointB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
+	"output_dir\x18\x03 \x01(\tR\toutputDir\x12-\n" +
+	"\x12inference_endpoint\x18\x04 \x01(\tR\x11inferenceEndpointB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
 
 var (
 	file_cassie_eval_proto_rawDescOnce sync.Once

--- a/protos/gen/cassie/eval.pb.go
+++ b/protos/gen/cassie/eval.pb.go
@@ -407,6 +407,82 @@ func (x *EvalDataset) GetSamples() []*EvalSample {
 	return nil
 }
 
+type ExperimentRun struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                                    // Name of the experiment, e.g. "aks_flag_eval"
+	DatasetPath       string                 `protobuf:"bytes,2,opt,name=dataset_path,json=datasetPath,proto3" json:"dataset_path,omitempty"`                   // Path to the YAML dataset to evaluate
+	CassieAuthCookie  string                 `protobuf:"bytes,3,opt,name=cassie_auth_cookie,json=cassieAuthCookie,proto3" json:"cassie_auth_cookie,omitempty"`  // Authorization cookie for backend eval server
+	OutputDir         string                 `protobuf:"bytes,4,opt,name=output_dir,json=outputDir,proto3" json:"output_dir,omitempty"`                         // Directory to write experiment reports
+	InferenceEndpoint string                 `protobuf:"bytes,5,opt,name=inference_endpoint,json=inferenceEndpoint,proto3" json:"inference_endpoint,omitempty"` // URL of the backend inference service
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ExperimentRun) Reset() {
+	*x = ExperimentRun{}
+	mi := &file_cassie_eval_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExperimentRun) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExperimentRun) ProtoMessage() {}
+
+func (x *ExperimentRun) ProtoReflect() protoreflect.Message {
+	mi := &file_cassie_eval_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExperimentRun.ProtoReflect.Descriptor instead.
+func (*ExperimentRun) Descriptor() ([]byte, []int) {
+	return file_cassie_eval_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ExperimentRun) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ExperimentRun) GetDatasetPath() string {
+	if x != nil {
+		return x.DatasetPath
+	}
+	return ""
+}
+
+func (x *ExperimentRun) GetCassieAuthCookie() string {
+	if x != nil {
+		return x.CassieAuthCookie
+	}
+	return ""
+}
+
+func (x *ExperimentRun) GetOutputDir() string {
+	if x != nil {
+		return x.OutputDir
+	}
+	return ""
+}
+
+func (x *ExperimentRun) GetInferenceEndpoint() string {
+	if x != nil {
+		return x.InferenceEndpoint
+	}
+	return ""
+}
+
 // Verifies that a shell command includes specific flags.
 type Assertion_ShellRequiredFlag struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -418,7 +494,7 @@ type Assertion_ShellRequiredFlag struct {
 
 func (x *Assertion_ShellRequiredFlag) Reset() {
 	*x = Assertion_ShellRequiredFlag{}
-	mi := &file_cassie_eval_proto_msgTypes[3]
+	mi := &file_cassie_eval_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -430,7 +506,7 @@ func (x *Assertion_ShellRequiredFlag) String() string {
 func (*Assertion_ShellRequiredFlag) ProtoMessage() {}
 
 func (x *Assertion_ShellRequiredFlag) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[3]
+	mi := &file_cassie_eval_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -470,7 +546,7 @@ type Assertion_ToolInvocation struct {
 
 func (x *Assertion_ToolInvocation) Reset() {
 	*x = Assertion_ToolInvocation{}
-	mi := &file_cassie_eval_proto_msgTypes[4]
+	mi := &file_cassie_eval_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -482,7 +558,7 @@ func (x *Assertion_ToolInvocation) String() string {
 func (*Assertion_ToolInvocation) ProtoMessage() {}
 
 func (x *Assertion_ToolInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[4]
+	mi := &file_cassie_eval_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -516,7 +592,7 @@ type Assertion_FileRetrieval struct {
 
 func (x *Assertion_FileRetrieval) Reset() {
 	*x = Assertion_FileRetrieval{}
-	mi := &file_cassie_eval_proto_msgTypes[5]
+	mi := &file_cassie_eval_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -528,7 +604,7 @@ func (x *Assertion_FileRetrieval) String() string {
 func (*Assertion_FileRetrieval) ProtoMessage() {}
 
 func (x *Assertion_FileRetrieval) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[5]
+	mi := &file_cassie_eval_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -558,7 +634,7 @@ func (x *Assertion_FileRetrieval) GetFileName() string {
 	return ""
 }
 
-// Asks an LLM to grade the assistant’s answer.
+// Asks an LLM to grade the assistant's answer.
 type Assertion_LLMJudge struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Prompt        string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
@@ -568,7 +644,7 @@ type Assertion_LLMJudge struct {
 
 func (x *Assertion_LLMJudge) Reset() {
 	*x = Assertion_LLMJudge{}
-	mi := &file_cassie_eval_proto_msgTypes[6]
+	mi := &file_cassie_eval_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -580,7 +656,7 @@ func (x *Assertion_LLMJudge) String() string {
 func (*Assertion_LLMJudge) ProtoMessage() {}
 
 func (x *Assertion_LLMJudge) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[6]
+	mi := &file_cassie_eval_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -613,7 +689,7 @@ type Assertion_CodeblockRegex struct {
 
 func (x *Assertion_CodeblockRegex) Reset() {
 	*x = Assertion_CodeblockRegex{}
-	mi := &file_cassie_eval_proto_msgTypes[7]
+	mi := &file_cassie_eval_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -625,7 +701,7 @@ func (x *Assertion_CodeblockRegex) String() string {
 func (*Assertion_CodeblockRegex) ProtoMessage() {}
 
 func (x *Assertion_CodeblockRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[7]
+	mi := &file_cassie_eval_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -698,7 +774,14 @@ const file_cassie_eval_proto_rawDesc = "" +
 	".AssertionR\n" +
 	"assertions\"4\n" +
 	"\vEvalDataset\x12%\n" +
-	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamplesB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
+	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\xc2\x01\n" +
+	"\rExperimentRun\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
+	"\fdataset_path\x18\x02 \x01(\tR\vdatasetPath\x12,\n" +
+	"\x12cassie_auth_cookie\x18\x03 \x01(\tR\x10cassieAuthCookie\x12\x1d\n" +
+	"\n" +
+	"output_dir\x18\x04 \x01(\tR\toutputDir\x12-\n" +
+	"\x12inference_endpoint\x18\x05 \x01(\tR\x11inferenceEndpointB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
 
 var (
 	file_cassie_eval_proto_rawDescOnce sync.Once
@@ -713,34 +796,35 @@ func file_cassie_eval_proto_rawDescGZIP() []byte {
 }
 
 var file_cassie_eval_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_cassie_eval_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_cassie_eval_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_cassie_eval_proto_goTypes = []any{
 	(Assertion_Type)(0),                 // 0: Assertion.Type
 	(Assertion_Result)(0),               // 1: Assertion.Result
 	(*Assertion)(nil),                   // 2: Assertion
 	(*EvalSample)(nil),                  // 3: EvalSample
 	(*EvalDataset)(nil),                 // 4: EvalDataset
-	(*Assertion_ShellRequiredFlag)(nil), // 5: Assertion.ShellRequiredFlag
-	(*Assertion_ToolInvocation)(nil),    // 6: Assertion.ToolInvocation
-	(*Assertion_FileRetrieval)(nil),     // 7: Assertion.FileRetrieval
-	(*Assertion_LLMJudge)(nil),          // 8: Assertion.LLMJudge
-	(*Assertion_CodeblockRegex)(nil),    // 9: Assertion.CodeblockRegex
+	(*ExperimentRun)(nil),               // 5: ExperimentRun
+	(*Assertion_ShellRequiredFlag)(nil), // 6: Assertion.ShellRequiredFlag
+	(*Assertion_ToolInvocation)(nil),    // 7: Assertion.ToolInvocation
+	(*Assertion_FileRetrieval)(nil),     // 8: Assertion.FileRetrieval
+	(*Assertion_LLMJudge)(nil),          // 9: Assertion.LLMJudge
+	(*Assertion_CodeblockRegex)(nil),    // 10: Assertion.CodeblockRegex
 }
 var file_cassie_eval_proto_depIdxs = []int32{
-	0, // 0: Assertion.type:type_name -> Assertion.Type
-	1, // 1: Assertion.result:type_name -> Assertion.Result
-	5, // 2: Assertion.shell_required_flag:type_name -> Assertion.ShellRequiredFlag
-	6, // 3: Assertion.tool_invocation:type_name -> Assertion.ToolInvocation
-	7, // 4: Assertion.file_retrieval:type_name -> Assertion.FileRetrieval
-	8, // 5: Assertion.llm_judge:type_name -> Assertion.LLMJudge
-	9, // 6: Assertion.codeblock_regex:type_name -> Assertion.CodeblockRegex
-	2, // 7: EvalSample.assertions:type_name -> Assertion
-	3, // 8: EvalDataset.samples:type_name -> EvalSample
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	0,  // 0: Assertion.type:type_name -> Assertion.Type
+	1,  // 1: Assertion.result:type_name -> Assertion.Result
+	6,  // 2: Assertion.shell_required_flag:type_name -> Assertion.ShellRequiredFlag
+	7,  // 3: Assertion.tool_invocation:type_name -> Assertion.ToolInvocation
+	8,  // 4: Assertion.file_retrieval:type_name -> Assertion.FileRetrieval
+	9,  // 5: Assertion.llm_judge:type_name -> Assertion.LLMJudge
+	10, // 6: Assertion.codeblock_regex:type_name -> Assertion.CodeblockRegex
+	2,  // 7: EvalSample.assertions:type_name -> Assertion
+	3,  // 8: EvalDataset.samples:type_name -> EvalSample
+	9,  // [9:9] is the sub-list for method output_type
+	9,  // [9:9] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_cassie_eval_proto_init() }
@@ -761,7 +845,7 @@ func file_cassie_eval_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cassie_eval_proto_rawDesc), len(file_cassie_eval_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protos/gen/cassie/eval.pb.go
+++ b/protos/gen/cassie/eval.pb.go
@@ -407,19 +407,131 @@ func (x *EvalDataset) GetSamples() []*EvalSample {
 	return nil
 }
 
-type Experiment struct {
-	state             protoimpl.MessageState `protogen:"open.v1"`
-	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                                    // Name of the experiment, e.g. "aks_flag_eval"
-	DatasetPath       string                 `protobuf:"bytes,2,opt,name=dataset_path,json=datasetPath,proto3" json:"dataset_path,omitempty"`                   // Path to the YAML dataset to evaluate
-	OutputDir         string                 `protobuf:"bytes,3,opt,name=output_dir,json=outputDir,proto3" json:"output_dir,omitempty"`                         // Directory to write experiment reports
-	InferenceEndpoint string                 `protobuf:"bytes,4,opt,name=inference_endpoint,json=inferenceEndpoint,proto3" json:"inference_endpoint,omitempty"` // URL of the backend inference service
+type ObjectMeta struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Name of the resource, e.g. "experiment-test".
+	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ObjectMeta) Reset() {
+	*x = ObjectMeta{}
+	mi := &file_cassie_eval_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ObjectMeta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ObjectMeta) ProtoMessage() {}
+
+func (x *ObjectMeta) ProtoReflect() protoreflect.Message {
+	mi := &file_cassie_eval_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ObjectMeta.ProtoReflect.Descriptor instead.
+func (*ObjectMeta) Descriptor() ([]byte, []int) {
+	return file_cassie_eval_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ObjectMeta) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type ExperimentSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Path to the YAML dataset to evaluate.
+	DatasetPath string `protobuf:"bytes,1,opt,name=dataset_path,json=datasetPath,proto3" json:"dataset_path,omitempty"`
+	// Directory where experiment reports will be written.
+	OutputDir string `protobuf:"bytes,2,opt,name=output_dir,json=outputDir,proto3" json:"output_dir,omitempty"`
+	// URL of the backend inference service to call during evaluation.
+	InferenceEndpoint string `protobuf:"bytes,3,opt,name=inference_endpoint,json=inferenceEndpoint,proto3" json:"inference_endpoint,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
+func (x *ExperimentSpec) Reset() {
+	*x = ExperimentSpec{}
+	mi := &file_cassie_eval_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExperimentSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExperimentSpec) ProtoMessage() {}
+
+func (x *ExperimentSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_cassie_eval_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExperimentSpec.ProtoReflect.Descriptor instead.
+func (*ExperimentSpec) Descriptor() ([]byte, []int) {
+	return file_cassie_eval_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ExperimentSpec) GetDatasetPath() string {
+	if x != nil {
+		return x.DatasetPath
+	}
+	return ""
+}
+
+func (x *ExperimentSpec) GetOutputDir() string {
+	if x != nil {
+		return x.OutputDir
+	}
+	return ""
+}
+
+func (x *ExperimentSpec) GetInferenceEndpoint() string {
+	if x != nil {
+		return x.InferenceEndpoint
+	}
+	return ""
+}
+
+type Experiment struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// API version of the resource, e.g. "cloudassistant.io/v1alpha1".
+	ApiVersion string `protobuf:"bytes,1,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	// Kind of the resource. Always "Experiment" for this CRD.
+	Kind string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	// Standard Kubernetes object metadata (name, labels, annotations, etc.).
+	Metadata *ObjectMeta `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// User-defined configuration for the experiment.
+	Spec          *ExperimentSpec `protobuf:"bytes,4,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
 func (x *Experiment) Reset() {
 	*x = Experiment{}
-	mi := &file_cassie_eval_proto_msgTypes[3]
+	mi := &file_cassie_eval_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -431,7 +543,7 @@ func (x *Experiment) String() string {
 func (*Experiment) ProtoMessage() {}
 
 func (x *Experiment) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[3]
+	mi := &file_cassie_eval_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -444,35 +556,35 @@ func (x *Experiment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Experiment.ProtoReflect.Descriptor instead.
 func (*Experiment) Descriptor() ([]byte, []int) {
-	return file_cassie_eval_proto_rawDescGZIP(), []int{3}
+	return file_cassie_eval_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *Experiment) GetName() string {
+func (x *Experiment) GetApiVersion() string {
 	if x != nil {
-		return x.Name
+		return x.ApiVersion
 	}
 	return ""
 }
 
-func (x *Experiment) GetDatasetPath() string {
+func (x *Experiment) GetKind() string {
 	if x != nil {
-		return x.DatasetPath
+		return x.Kind
 	}
 	return ""
 }
 
-func (x *Experiment) GetOutputDir() string {
+func (x *Experiment) GetMetadata() *ObjectMeta {
 	if x != nil {
-		return x.OutputDir
+		return x.Metadata
 	}
-	return ""
+	return nil
 }
 
-func (x *Experiment) GetInferenceEndpoint() string {
+func (x *Experiment) GetSpec() *ExperimentSpec {
 	if x != nil {
-		return x.InferenceEndpoint
+		return x.Spec
 	}
-	return ""
+	return nil
 }
 
 // Verifies that a shell command includes specific flags.
@@ -486,7 +598,7 @@ type Assertion_ShellRequiredFlag struct {
 
 func (x *Assertion_ShellRequiredFlag) Reset() {
 	*x = Assertion_ShellRequiredFlag{}
-	mi := &file_cassie_eval_proto_msgTypes[4]
+	mi := &file_cassie_eval_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -498,7 +610,7 @@ func (x *Assertion_ShellRequiredFlag) String() string {
 func (*Assertion_ShellRequiredFlag) ProtoMessage() {}
 
 func (x *Assertion_ShellRequiredFlag) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[4]
+	mi := &file_cassie_eval_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -538,7 +650,7 @@ type Assertion_ToolInvocation struct {
 
 func (x *Assertion_ToolInvocation) Reset() {
 	*x = Assertion_ToolInvocation{}
-	mi := &file_cassie_eval_proto_msgTypes[5]
+	mi := &file_cassie_eval_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -550,7 +662,7 @@ func (x *Assertion_ToolInvocation) String() string {
 func (*Assertion_ToolInvocation) ProtoMessage() {}
 
 func (x *Assertion_ToolInvocation) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[5]
+	mi := &file_cassie_eval_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -584,7 +696,7 @@ type Assertion_FileRetrieval struct {
 
 func (x *Assertion_FileRetrieval) Reset() {
 	*x = Assertion_FileRetrieval{}
-	mi := &file_cassie_eval_proto_msgTypes[6]
+	mi := &file_cassie_eval_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -596,7 +708,7 @@ func (x *Assertion_FileRetrieval) String() string {
 func (*Assertion_FileRetrieval) ProtoMessage() {}
 
 func (x *Assertion_FileRetrieval) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[6]
+	mi := &file_cassie_eval_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -636,7 +748,7 @@ type Assertion_LLMJudge struct {
 
 func (x *Assertion_LLMJudge) Reset() {
 	*x = Assertion_LLMJudge{}
-	mi := &file_cassie_eval_proto_msgTypes[7]
+	mi := &file_cassie_eval_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -648,7 +760,7 @@ func (x *Assertion_LLMJudge) String() string {
 func (*Assertion_LLMJudge) ProtoMessage() {}
 
 func (x *Assertion_LLMJudge) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[7]
+	mi := &file_cassie_eval_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -681,7 +793,7 @@ type Assertion_CodeblockRegex struct {
 
 func (x *Assertion_CodeblockRegex) Reset() {
 	*x = Assertion_CodeblockRegex{}
-	mi := &file_cassie_eval_proto_msgTypes[8]
+	mi := &file_cassie_eval_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -693,7 +805,7 @@ func (x *Assertion_CodeblockRegex) String() string {
 func (*Assertion_CodeblockRegex) ProtoMessage() {}
 
 func (x *Assertion_CodeblockRegex) ProtoReflect() protoreflect.Message {
-	mi := &file_cassie_eval_proto_msgTypes[8]
+	mi := &file_cassie_eval_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -766,14 +878,22 @@ const file_cassie_eval_proto_rawDesc = "" +
 	".AssertionR\n" +
 	"assertions\"4\n" +
 	"\vEvalDataset\x12%\n" +
-	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\x91\x01\n" +
+	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\" \n" +
 	"\n" +
-	"Experiment\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
-	"\fdataset_path\x18\x02 \x01(\tR\vdatasetPath\x12\x1d\n" +
+	"ObjectMeta\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\x81\x01\n" +
+	"\x0eExperimentSpec\x12!\n" +
+	"\fdataset_path\x18\x01 \x01(\tR\vdatasetPath\x12\x1d\n" +
 	"\n" +
-	"output_dir\x18\x03 \x01(\tR\toutputDir\x12-\n" +
-	"\x12inference_endpoint\x18\x04 \x01(\tR\x11inferenceEndpointB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
+	"output_dir\x18\x02 \x01(\tR\toutputDir\x12-\n" +
+	"\x12inference_endpoint\x18\x03 \x01(\tR\x11inferenceEndpoint\"\x8f\x01\n" +
+	"\n" +
+	"Experiment\x12\x1f\n" +
+	"\vapi_version\x18\x01 \x01(\tR\n" +
+	"apiVersion\x12\x12\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\x12'\n" +
+	"\bmetadata\x18\x03 \x01(\v2\v.ObjectMetaR\bmetadata\x12#\n" +
+	"\x04spec\x18\x04 \x01(\v2\x0f.ExperimentSpecR\x04specB4Z2github.com/jlewi/cloud-assistant/protos/gen/cassieb\x06proto3"
 
 var (
 	file_cassie_eval_proto_rawDescOnce sync.Once
@@ -788,35 +908,39 @@ func file_cassie_eval_proto_rawDescGZIP() []byte {
 }
 
 var file_cassie_eval_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_cassie_eval_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_cassie_eval_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_cassie_eval_proto_goTypes = []any{
 	(Assertion_Type)(0),                 // 0: Assertion.Type
 	(Assertion_Result)(0),               // 1: Assertion.Result
 	(*Assertion)(nil),                   // 2: Assertion
 	(*EvalSample)(nil),                  // 3: EvalSample
 	(*EvalDataset)(nil),                 // 4: EvalDataset
-	(*Experiment)(nil),                  // 5: Experiment
-	(*Assertion_ShellRequiredFlag)(nil), // 6: Assertion.ShellRequiredFlag
-	(*Assertion_ToolInvocation)(nil),    // 7: Assertion.ToolInvocation
-	(*Assertion_FileRetrieval)(nil),     // 8: Assertion.FileRetrieval
-	(*Assertion_LLMJudge)(nil),          // 9: Assertion.LLMJudge
-	(*Assertion_CodeblockRegex)(nil),    // 10: Assertion.CodeblockRegex
+	(*ObjectMeta)(nil),                  // 5: ObjectMeta
+	(*ExperimentSpec)(nil),              // 6: ExperimentSpec
+	(*Experiment)(nil),                  // 7: Experiment
+	(*Assertion_ShellRequiredFlag)(nil), // 8: Assertion.ShellRequiredFlag
+	(*Assertion_ToolInvocation)(nil),    // 9: Assertion.ToolInvocation
+	(*Assertion_FileRetrieval)(nil),     // 10: Assertion.FileRetrieval
+	(*Assertion_LLMJudge)(nil),          // 11: Assertion.LLMJudge
+	(*Assertion_CodeblockRegex)(nil),    // 12: Assertion.CodeblockRegex
 }
 var file_cassie_eval_proto_depIdxs = []int32{
 	0,  // 0: Assertion.type:type_name -> Assertion.Type
 	1,  // 1: Assertion.result:type_name -> Assertion.Result
-	6,  // 2: Assertion.shell_required_flag:type_name -> Assertion.ShellRequiredFlag
-	7,  // 3: Assertion.tool_invocation:type_name -> Assertion.ToolInvocation
-	8,  // 4: Assertion.file_retrieval:type_name -> Assertion.FileRetrieval
-	9,  // 5: Assertion.llm_judge:type_name -> Assertion.LLMJudge
-	10, // 6: Assertion.codeblock_regex:type_name -> Assertion.CodeblockRegex
+	8,  // 2: Assertion.shell_required_flag:type_name -> Assertion.ShellRequiredFlag
+	9,  // 3: Assertion.tool_invocation:type_name -> Assertion.ToolInvocation
+	10, // 4: Assertion.file_retrieval:type_name -> Assertion.FileRetrieval
+	11, // 5: Assertion.llm_judge:type_name -> Assertion.LLMJudge
+	12, // 6: Assertion.codeblock_regex:type_name -> Assertion.CodeblockRegex
 	2,  // 7: EvalSample.assertions:type_name -> Assertion
 	3,  // 8: EvalDataset.samples:type_name -> EvalSample
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	5,  // 9: Experiment.metadata:type_name -> ObjectMeta
+	6,  // 10: Experiment.spec:type_name -> ExperimentSpec
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_cassie_eval_proto_init() }
@@ -837,7 +961,7 @@ func file_cassie_eval_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_cassie_eval_proto_rawDesc), len(file_cassie_eval_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/protos/gen/cassie/eval.pb.go
+++ b/protos/gen/cassie/eval.pb.go
@@ -407,7 +407,7 @@ func (x *EvalDataset) GetSamples() []*EvalSample {
 	return nil
 }
 
-type ExperimentRun struct {
+type Experiment struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`                                                    // Name of the experiment, e.g. "aks_flag_eval"
 	DatasetPath       string                 `protobuf:"bytes,2,opt,name=dataset_path,json=datasetPath,proto3" json:"dataset_path,omitempty"`                   // Path to the YAML dataset to evaluate
@@ -418,20 +418,20 @@ type ExperimentRun struct {
 	sizeCache         protoimpl.SizeCache
 }
 
-func (x *ExperimentRun) Reset() {
-	*x = ExperimentRun{}
+func (x *Experiment) Reset() {
+	*x = Experiment{}
 	mi := &file_cassie_eval_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ExperimentRun) String() string {
+func (x *Experiment) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ExperimentRun) ProtoMessage() {}
+func (*Experiment) ProtoMessage() {}
 
-func (x *ExperimentRun) ProtoReflect() protoreflect.Message {
+func (x *Experiment) ProtoReflect() protoreflect.Message {
 	mi := &file_cassie_eval_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -443,40 +443,40 @@ func (x *ExperimentRun) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ExperimentRun.ProtoReflect.Descriptor instead.
-func (*ExperimentRun) Descriptor() ([]byte, []int) {
+// Deprecated: Use Experiment.ProtoReflect.Descriptor instead.
+func (*Experiment) Descriptor() ([]byte, []int) {
 	return file_cassie_eval_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *ExperimentRun) GetName() string {
+func (x *Experiment) GetName() string {
 	if x != nil {
 		return x.Name
 	}
 	return ""
 }
 
-func (x *ExperimentRun) GetDatasetPath() string {
+func (x *Experiment) GetDatasetPath() string {
 	if x != nil {
 		return x.DatasetPath
 	}
 	return ""
 }
 
-func (x *ExperimentRun) GetCassieAuthCookie() string {
+func (x *Experiment) GetCassieAuthCookie() string {
 	if x != nil {
 		return x.CassieAuthCookie
 	}
 	return ""
 }
 
-func (x *ExperimentRun) GetOutputDir() string {
+func (x *Experiment) GetOutputDir() string {
 	if x != nil {
 		return x.OutputDir
 	}
 	return ""
 }
 
-func (x *ExperimentRun) GetInferenceEndpoint() string {
+func (x *Experiment) GetInferenceEndpoint() string {
 	if x != nil {
 		return x.InferenceEndpoint
 	}
@@ -774,8 +774,9 @@ const file_cassie_eval_proto_rawDesc = "" +
 	".AssertionR\n" +
 	"assertions\"4\n" +
 	"\vEvalDataset\x12%\n" +
-	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\xc2\x01\n" +
-	"\rExperimentRun\x12\x12\n" +
+	"\asamples\x18\x01 \x03(\v2\v.EvalSampleR\asamples\"\xbf\x01\n" +
+	"\n" +
+	"Experiment\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12!\n" +
 	"\fdataset_path\x18\x02 \x01(\tR\vdatasetPath\x12,\n" +
 	"\x12cassie_auth_cookie\x18\x03 \x01(\tR\x10cassieAuthCookie\x12\x1d\n" +
@@ -803,7 +804,7 @@ var file_cassie_eval_proto_goTypes = []any{
 	(*Assertion)(nil),                   // 2: Assertion
 	(*EvalSample)(nil),                  // 3: EvalSample
 	(*EvalDataset)(nil),                 // 4: EvalDataset
-	(*ExperimentRun)(nil),               // 5: ExperimentRun
+	(*Experiment)(nil),                  // 5: Experiment
 	(*Assertion_ShellRequiredFlag)(nil), // 6: Assertion.ShellRequiredFlag
 	(*Assertion_ToolInvocation)(nil),    // 7: Assertion.ToolInvocation
 	(*Assertion_FileRetrieval)(nil),     // 8: Assertion.FileRetrieval


### PR DESCRIPTION
### ✨  What’s new
- **`ExperimentRun` proto**  
  * `name`, `dataset_path`, `cassie_auth_cookie`, `output_dir`, `inference_endpoint` capture everything needed to run an experiment.
- **CLI rewrite** (`app/cmd/eval.go`)  
  * `cas eval` now takes **one argument** – the experiment YAML – instead of `<yaml-file> <target-url>`.
  * Reads the YAML → JSON → `ExperimentRun` proto → kicks off evaluation with `ai.EvalFromExperimentRun`.
- **Evaluation pipeline cleanup** (`app/pkg/ai/eval.go`)  
  * Added `EvalFromExperimentRun` and refactored `runInference` to accept `cassieCookie` & `inferenceEndpoint` directly.  
  * Removed the older `EvalFromYAML` / `EvalFromProto` paths and the `config.CloudAssistant` dependency.
- **Config check removed** (`app/pkg/application/app.go`) – eval no longer requires `cloudAssistant` block.
- **Docs updated** (`docs/evals.md`) with a clearer 4-step Quick Start showing dataset & experiment YAMLs.
- **Proto / generated code regenerated** (`protos/cassie/eval.proto`, `*.pb.go`) to include `ExperimentRun`.

