### PR TITLE
Implement markdown report generation for AI evaluation results

### DIFF
--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -10,11 +10,15 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"runtime"
+	"sort"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/cloud-assistant/app/pkg/logs"
+	"github.com/jlewi/cloud-assistant/app/pkg/version"
 	"github.com/jlewi/cloud-assistant/protos/gen/cassie"
 	"github.com/jlewi/cloud-assistant/protos/gen/cassie/cassieconnect"
 	"github.com/pkg/errors"
@@ -241,6 +245,75 @@ func runInference(input string, cassieCookie string, inferenceEndpoint string) (
 	return blocks, nil
 }
 
+// markdownReport holds the data needed to render the evaluation markdown report
+type markdownReport struct {
+	ExperimentName     string
+	DatasetName        string
+	NumSamples         int
+	NumAssertions      int
+	NumPassed          int
+	NumFailed          int
+	NumSkipped         int
+	AssertionTypeStats map[string]struct{ Passed, Failed, Skipped int }
+	FailedAssertions   []struct {
+		Sample    string
+		Assertion string
+		Reason    string
+	}
+	Commit    string
+	Version   string
+	Model     string
+	Runner    string
+	GoVersion string
+	Date      string
+}
+
+func (r *markdownReport) Render() string {
+	passRate := 0.0
+	if r.NumAssertions > 0 {
+		passRate = float64(r.NumPassed) / float64(r.NumPassed+r.NumFailed) * 100
+	}
+	lines := []string{}
+	lines = append(lines, fmt.Sprintf("# AI-SRE Level-1 Evaluation — %s", r.Date))
+	lines = append(lines, "")
+	lines = append(lines, "| Metric | Value |\n|--------|------:|")
+	lines = append(lines, fmt.Sprintf("| Datasets              | `%s` |", r.DatasetName))
+	lines = append(lines, fmt.Sprintf("| Samples               | %d |", r.NumSamples))
+	lines = append(lines, fmt.Sprintf("| Assertions  | %d |", r.NumAssertions))
+	lines = append(lines, fmt.Sprintf("| **Pass rate**         | **%.0f %%** (%d / %d) |", passRate, r.NumPassed, r.NumPassed+r.NumFailed))
+	lines = append(lines, "")
+	lines = append(lines, "## Pass / fail by assertion type")
+	lines = append(lines, "| Assertion | ✅ Passed | ❌ Failed | ⏭️ Skipped | Pass % |")
+	lines = append(lines, "|-----------|----------:|---------:|----------:|-------:|")
+	// Sort assertion types for stable output
+	var types []string
+	for typ := range r.AssertionTypeStats {
+		types = append(types, typ)
+	}
+	sort.Strings(types)
+	for _, typ := range types {
+		stat := r.AssertionTypeStats[typ]
+		total := stat.Passed + stat.Failed
+		passPct := 0.0
+		if total > 0 {
+			passPct = float64(stat.Passed) / float64(total) * 100
+		}
+		lines = append(lines, fmt.Sprintf("| `%s` | %d | %d | %d | %.0f %% |", typ, stat.Passed, stat.Failed, stat.Skipped, passPct))
+	}
+	lines = append(lines, "")
+	if len(r.FailedAssertions) > 0 {
+		lines = append(lines, fmt.Sprintf("<details>\n<summary>❌ %d failed assertions (click to expand)</summary>\n", len(r.FailedAssertions)))
+		lines = append(lines, "\n| Sample | Assertion | Reason |\n|--------|-----------|--------|")
+		for _, fail := range r.FailedAssertions {
+			lines = append(lines, fmt.Sprintf("| `%s` | `%s` | %s |", fail.Sample, fail.Assertion, fail.Reason))
+		}
+		lines = append(lines, "\n</details>\n")
+	}
+	lines = append(lines, "")
+	lines = append(lines, fmt.Sprintf("_Run metadata: commit `%s`, version `%s`, model `%s`, runner `%s`, Go %s_", r.Commit, r.Version, r.Model, r.Runner, r.GoVersion))
+	return strings.Join(lines, "\n")
+}
+
 // EvalFromExperiment runs an experiment based on the Experiment config.
 func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[string]*cassie.Block, error) {
 	// Read the experiment YAML file
@@ -266,6 +339,26 @@ func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[s
 	cassieCookie := cookie["cassie-session"]
 	inferenceEndpoint := exp.Spec.GetInferenceEndpoint()
 
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	report := &markdownReport{
+		ExperimentName:     exp.Metadata.GetName(),
+		DatasetName:        exp.Spec.GetDatasetPath(),
+		NumSamples:         len(dataset.Samples),
+		AssertionTypeStats: map[string]struct{ Passed, Failed, Skipped int }{},
+		Commit:             version.Commit,
+		Version:            version.Version,
+		Model:              "gpt-4o-mini", // TODO: fetch dynamically if possible
+		Runner:             "linux-amd64", // TODO: fetch dynamically if possible
+		GoVersion:          runtime.Version(),
+		Date:               time.Now().In(loc).Format("2006-01-02 15:04 MST"),
+	}
+
+	totalAssertions := 0
+	numPassed := 0
+	numFailed := 0
+	numSkipped := 0
+	failedAssertions := []struct{ Sample, Assertion, Reason string }{}
+
 	for _, sample := range dataset.Samples {
 		blocks, err := runInference(sample.InputText, cassieCookie, inferenceEndpoint)
 		if err != nil {
@@ -276,14 +369,43 @@ func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[s
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to assert %q", assertion.Name)
 			}
+			totalAssertions++
+			typeName := assertion.Type.String()
+			stat := report.AssertionTypeStats[typeName]
+			switch assertion.Result {
+			case cassie.Assertion_RESULT_TRUE:
+				numPassed++
+				stat.Passed++
+			case cassie.Assertion_RESULT_FALSE:
+				numFailed++
+				stat.Failed++
+				failedAssertions = append(failedAssertions, struct{ Sample, Assertion, Reason string }{
+					Sample:    sample.Name,
+					Assertion: assertion.Name,
+					Reason:    "failed", // TODO: add more detailed reason if available
+				})
+			case cassie.Assertion_RESULT_SKIPPED:
+				numSkipped++
+				stat.Skipped++
+			}
+			report.AssertionTypeStats[typeName] = stat
 		}
-		fmt.Println("\nBlocks received:")
-		for _, block := range blocks {
-			fmt.Printf("block id: %s contents: %s\n", block.Id, block.Contents)
-		}
-		fmt.Println("\nBlocks:")
-		fmt.Println(blocks)
-		fmt.Println("\n--------------------------------")
 	}
+	report.NumAssertions = totalAssertions
+	report.NumPassed = numPassed
+	report.NumFailed = numFailed
+	report.NumSkipped = numSkipped
+	report.FailedAssertions = failedAssertions
+
+	// Write markdown report to outputDir
+	outputDir := exp.Spec.GetOutputDir()
+	if outputDir == "" {
+		outputDir = "."
+	}
+	reportPath := outputDir + "/eval_report.md"
+	if err := os.WriteFile(reportPath, []byte(report.Render()), 0644); err != nil {
+		return nil, errors.Wrapf(err, "failed to write markdown report to %s", reportPath)
+	}
+
 	return nil, nil
 }

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -402,7 +402,6 @@ func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[s
 	if outputDir == "" {
 		outputDir = "."
 	}
-	loc, _ = time.LoadLocation("America/Los_Angeles")
 	timestamp := time.Now().In(loc).Format("20060102_150405")
 	reportPath := fmt.Sprintf("%s/eval_report_%s.md", outputDir, timestamp)
 	if err := os.WriteFile(reportPath, []byte(report.Render()), 0644); err != nil {

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -269,8 +269,8 @@ type markdownReport struct {
 }
 
 func (r *markdownReport) Render() string {
-	passRate := 0.0
-	if r.NumAssertions > 0 {
+	passRate := 100.0
+	if r.NumPassed+r.NumFailed > 0 {
 		passRate = float64(r.NumPassed) / float64(r.NumPassed+r.NumFailed) * 100
 	}
 	lines := []string{}

--- a/app/pkg/ai/eval.go
+++ b/app/pkg/ai/eval.go
@@ -310,7 +310,7 @@ func (r *markdownReport) Render() string {
 		lines = append(lines, "\n</details>\n")
 	}
 	lines = append(lines, "")
-	lines = append(lines, fmt.Sprintf("_Run metadata: commit `%s`, version `%s`, model `%s`, runner `%s`, Go %s_", r.Commit, r.Version, r.Model, r.Runner, r.GoVersion))
+	lines = append(lines, fmt.Sprintf("_Run metadata: commit `%s`, version `%s`, model `%s`, runner `%s`, %s_", r.Commit, r.Version, r.Model, r.Runner, r.GoVersion))
 	return strings.Join(lines, "\n")
 }
 
@@ -402,7 +402,9 @@ func EvalFromExperiment(exp *cassie.Experiment, cookie map[string]string) (map[s
 	if outputDir == "" {
 		outputDir = "."
 	}
-	reportPath := outputDir + "/eval_report.md"
+	loc, _ = time.LoadLocation("America/Los_Angeles")
+	timestamp := time.Now().In(loc).Format("20060102_150405")
+	reportPath := fmt.Sprintf("%s/eval_report_%s.md", outputDir, timestamp)
 	if err := os.WriteFile(reportPath, []byte(report.Render()), 0644); err != nil {
 		return nil, errors.Wrapf(err, "failed to write markdown report to %s", reportPath)
 	}

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -77,10 +77,14 @@ This document explains **Level 1 evaluations** for the AI SRE project—simple, 
    Point the experiment at the dataset and your Cassie backend.
 
    ```yaml
-   name: "experiment_test"
-   dataset_path: "./dataset/dataset_test.yaml"   # path to the dataset file above
-   output_dir: "./experiments/out"             # where reports will be written
-   inference_endpoint: "http://localhost:8080" # Cassie inference service
+   apiVersion: cloudassistant.io/v1alpha1
+   kind: Experiment
+   metadata:
+      name: experiment-test 
+   spec:
+      datasetPath: "./dataset/dataset_test.yaml"  # path to the dataset file above
+      outputDir:   "./experiments/out" # where reports will be written
+      inferenceEndpoint: "http://localhost:8080" # Cassie inference service
    ```
 
 5. **Run the evaluation**


### PR DESCRIPTION
Here is an example result:

# AI-SRE Level-1 Evaluation — 2025-06-04 15:11 PDT

| Metric | Value |
|--------|------:|
| Datasets              | `/Users/zizheng/project/cloud-assistant/docs/dataset_test.yaml` |
| Samples               | 3 |
| Assertions  | 4 |
| **Pass rate**         | **67 %** (2 / 3) |

## Pass / fail by assertion type
| Assertion | ✅ Passed | ❌ Failed | ⏭️ Skipped | Pass % |
|-----------|----------:|---------:|----------:|-------:|
| `TYPE_CODEBLOCK_REGEX` | 1 | 0 | 0 | 100 % |
| `TYPE_FILE_RETRIEVED` | 1 | 0 | 0 | 100 % |
| `TYPE_SHELL_REQUIRED_FLAG` | 0 | 1 | 1 | 0 % |

<details>
<summary>❌ 1 failed assertions (click to expand)</summary>


| Sample | Assertion | Reason |
|--------|-----------|--------|
| `test_AKS_required_flags` | `az_aks_has_required_flag` | failed |

</details>


_Run metadata: commit `3818049cd0c975ad70562186b67d184830e9bb21`, version `0.0.1-41-g3818049-3818049`, model `gpt-4o-mini`, runner `linux-amd64`, go1.24.0_