### PR TITLE
No reconnect for runner auth check, if it errors the user needs to know

### DIFF
--- a/web/src/components/Runme/Streams.tsx
+++ b/web/src/components/Runme/Streams.tsx
@@ -330,7 +330,10 @@ class Streams {
 
       const onError = (event: Event) => {
         console.log(new Date(), `WebSocket transport ${streamID} error`, event)
-        // observer.error(event)
+        // If autoReconnect is disabled, we want to error out immediately.
+        if (!this.autoReconnect) {
+          observer.error(event)
+        }
       }
 
       const onMessage = (event: MessageEvent) => {

--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -122,7 +122,7 @@ export const SettingsProvider = ({
       { knownID: `check_${ulid()}`, runID: genRunID(), sequence: 0 },
       {
         runnerEndpoint: settings.webApp.runner,
-        autoReconnect: settings.webApp.reconnect,
+        autoReconnect: false, // let it fail, we're interested in the error
       }
     )
 


### PR DESCRIPTION
This restores the immediate user feedback if the runner in the settings is invalid.